### PR TITLE
Move validation out of Formless & make form specs simpler for users

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -24,7 +24,7 @@
     "purescript-halogen-storybook": "^0.4.0",
     "purescript-debug": "^4.0.0",
     "purescript-validation": "^4.0.0",
-    "purescript-polyform": "^0.7.0",
-    "purescript-test-unit": "^14.0.0"
+    "purescript-test-unit": "^14.0.0",
+    "purescript-read": "^1.0.1"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -22,6 +22,9 @@
   "devDependencies": {
     "purescript-ocelot": "git@github.com:citizennet/purescript-ocelot.git#master",
     "purescript-halogen-storybook": "^0.4.0",
-    "purescript-debug": "^4.0.0"
+    "purescript-debug": "^4.0.0",
+    "purescript-validation": "^4.0.0",
+    "purescript-polyform": "^0.7.0",
+    "purescript-test-unit": "^14.0.0"
   }
 }

--- a/example/Main.purs
+++ b/example/Main.purs
@@ -6,9 +6,10 @@ import Data.Maybe (Maybe(..))
 import Data.Tuple (Tuple(..))
 import Effect (Effect)
 import Effect.Aff (Aff)
-import Example.Home as Home
 import Example.Basic.Component as Basic
 import Example.ExternalComponents.Component as ExternalComponents
+import Example.Home as Home
+import Example.RealWorld.Component as RealWorld
 import Foreign.Object as Object
 import Halogen.Aff as HA
 import Halogen.HTML (text) as HH
@@ -19,6 +20,7 @@ stories = Object.fromFoldable
   [ Tuple "" $ proxy Home.component
   , Tuple "basic" $ proxy Basic.component
   , Tuple "external-components" $ proxy ExternalComponents.component
+  , Tuple "real-world" $ proxy RealWorld.component
   ]
 
 main :: Effect Unit

--- a/example/Validation/Semigroup.purs
+++ b/example/Validation/Semigroup.purs
@@ -36,7 +36,7 @@ newtype Password = Password String
 -- | Type of validation errors encountered when validating form fields
 data InvalidField
   = InvalidEmailAddress (NonEmptyList InvalidPrimitive)
- 	| InvalidPassword     (NonEmptyList InvalidPrimitive)
+   | InvalidPassword     (NonEmptyList InvalidPrimitive)
 
 validateEmailAddress
   :: String
@@ -45,7 +45,7 @@ validateEmailAddress input =
       let result =
                validateNonEmpty input
             *> validateEmailRegex input
-  	  in bimap (singleton <<< InvalidEmailAddress) EmailAddress result
+      in bimap (singleton <<< InvalidEmailAddress) EmailAddress result
 
 validatePassword
   :: String

--- a/example/Validation/Semigroup.purs
+++ b/example/Validation/Semigroup.purs
@@ -1,0 +1,184 @@
+-- | Credit: Joe Kachmar's 2018 presentation at LambdaConf:
+-- | https://github.com/jkachmar/lc2018
+-- |
+-- | Code here is untouched from the section 'Exercise 4'
+
+module Example.Validation.Semigroup where
+
+import Prelude
+
+import Data.Array (fromFoldable)
+import Data.Bifunctor (bimap)
+import Data.Either (fromRight)
+import Data.Generic.Rep (class Generic)
+import Data.Generic.Rep.Show (genericShow)
+import Data.List.NonEmpty (NonEmptyList, singleton)
+import Data.Newtype (class Newtype, unwrap)
+import Data.String (null, length, toLower, toUpper)
+import Data.String.Regex (Regex, regex, test)
+import Data.String.Regex.Flags (noFlags)
+import Data.Validation.Semigroup (V, invalid, unV)
+import Global.Unsafe (unsafeStringify)
+import Partial.Unsafe (unsafePartial)
+
+--------------------------------------------------------------------------------
+-- TYPES AND FUNCTIONS FOR FIELD VALIDATIONS
+
+-- | Newtype wrapper for `String` indicating a valid email address
+newtype EmailAddress = EmailAddress String
+
+-- | Newtype wrapper for `String` indicating a valid password
+newtype Password = Password String
+
+-- | Type of validation errors encountered when validating form fields
+data InvalidField
+  = InvalidEmailAddress (NonEmptyList InvalidPrimitive)
+ 	| InvalidPassword     (NonEmptyList InvalidPrimitive)
+
+validateEmailAddress
+  :: String
+  -> V (NonEmptyList InvalidField) EmailAddress
+validateEmailAddress input =
+      let result =
+               validateNonEmpty input
+            *> validateEmailRegex input
+  	  in bimap (singleton <<< InvalidEmailAddress) EmailAddress result
+
+validatePassword
+  :: String
+  -> Int
+  -> Int
+  -> V (NonEmptyList InvalidField) Password
+validatePassword input minLength maxLength =
+     let result =
+              validateNonEmpty input
+           *> validateContainsMixedCase input
+           *> (validateLength input minLength maxLength)
+     in bimap (singleton <<< InvalidPassword) Password result
+
+--------------------------------------------------------------------------------
+-- TYPES AND FUNCTIONS FOR PRIMITIVE VALIDATIONS
+
+-- | Type of validation errors encountered when validating primitive input
+data InvalidPrimitive
+  = EmptyField
+  | InvalidEmail String
+  | TooShort Int Int
+  | TooLong Int Int
+  | NoLowercase String
+  | NoUppercase String
+
+-- | Validate that an input string is not empty
+validateNonEmpty :: String -> V (NonEmptyList InvalidPrimitive) String
+validateNonEmpty input
+  | null input = invalid (singleton EmptyField)
+  | otherwise = pure input
+
+-- | Validates that an input string conforms to some regular expression that
+-- | checks for valid email addresses
+validateEmailRegex :: String -> V (NonEmptyList InvalidPrimitive) String
+validateEmailRegex input
+  | test emailRegex input = pure input
+  | otherwise = invalid (singleton (InvalidEmail input))
+
+-- | Validate that an input string is at least as long as some given `Int`
+validateMinimumLength
+  :: String
+  -> Int
+  -> V (NonEmptyList InvalidPrimitive) String
+validateMinimumLength input minLength
+  | (length input) < minLength = invalid (singleton (TooShort (length input) minLength))
+  | otherwise = pure input
+
+-- | Validate that an input string is shorter than given `Int`
+validateMaximumLength
+  :: String
+  -> Int
+  -> V (NonEmptyList InvalidPrimitive) String
+validateMaximumLength input maxLength
+  | (length input) > maxLength = invalid (singleton (TooLong (length input) maxLength))
+  | otherwise = pure input
+
+-- | Validate that an input string is within the minimum and maximum given `Int`
+-- | lengths
+validateLength
+  :: String
+  -> Int
+  -> Int
+  -> V (NonEmptyList InvalidPrimitive) String
+validateLength input minLength maxLength =
+     validateMinimumLength input minLength
+  *> validateMaximumLength input maxLength
+
+-- | Validate that an input string contains at least one lowercase character
+validateContainsLowercase
+  :: String
+  -> V (NonEmptyList InvalidPrimitive) String
+validateContainsLowercase input
+  | (toUpper input) == input = invalid (singleton (NoLowercase input))
+  | otherwise = pure input
+
+-- | Validate that an input string contains at least one uppercase character
+validateContainsUppercase
+  :: String
+  -> V (NonEmptyList InvalidPrimitive) String
+validateContainsUppercase input
+  | (toLower input) == input = invalid (singleton (NoUppercase input))
+  | otherwise = pure input
+
+-- | Validate that an input string contains some mix of upper- and lowercase
+-- | characters
+validateContainsMixedCase
+  :: String
+  -> V (NonEmptyList InvalidPrimitive) String
+validateContainsMixedCase input =
+     validateContainsLowercase input
+  *> validateContainsUppercase input
+
+---------------------------------------------------------------------------------
+-- !!! BOILERPLATE TO MAKE EVERYTHING A LITTLE EASIER TO WORK WITH            !!!
+---------------------------------------------------------------------------------
+
+-- | Helper function to print validations
+printValidation
+  :: forall err result
+   . Show err
+  => V (NonEmptyList err) result
+  -> String
+printValidation =
+  unV (show <<< fromFoldable) (\result -> "Valid: " <> (unsafeStringify result))
+
+-- | Derive a `Generic` instance for `InvalidPrimitive` so we can get a `Show`
+-- | instance to print to the console.
+derive instance genericInvalidPrimitive :: Generic InvalidPrimitive _
+
+-- | Derive `show` for `InvalidPrimitive` using the `Generic` instance.
+instance showInvalidPrimitive :: Show InvalidPrimitive where
+  show = genericShow
+
+-- | Utility function to unsafely construct a regular expression from a pattern
+-- | string.
+-- |
+-- | This will fail at runtime with an error if the pattern string is invalid.
+unsafeRegexFromString :: String -> Regex
+unsafeRegexFromString str = unsafePartial (fromRight (regex str noFlags))
+
+-- | Regular expression for email address validation.
+emailRegex :: Regex
+emailRegex =
+  unsafeRegexFromString "^\\w+([.-]?\\w+)*@\\w+([.-]?\\w+)*(\\.\\w{2,3})+$"
+
+-- | Manually derive a `Show` instance for `EmailAddress` so it prints nicely
+derive instance newtypeEmailAddress :: Newtype EmailAddress _
+instance showEmailAddress :: Show EmailAddress where show = unwrap
+
+-- | Manually derive a `Show` instance for `Password` so it prints nicely
+derive instance newtypePassword :: Newtype Password _
+instance showPassword :: Show Password where show = unwrap
+
+-- | Manually derive a `Show` instance for `InvalidField` that pretty prints the
+-- | `NonEmptyList`s as `Array`s
+instance showInvalidField :: Show InvalidField where
+  show = case _ of
+    InvalidEmailAddress errs -> "(InvalidEmailAddress " <> (show (fromFoldable errs)) <> ")"
+    InvalidPassword     errs -> "(InvalidPassword "     <> (show (fromFoldable errs)) <> ")"

--- a/example/Validation/Semigroup.purs
+++ b/example/Validation/Semigroup.purs
@@ -1,7 +1,7 @@
 -- | Credit: Joe Kachmar's 2018 presentation at LambdaConf:
 -- | https://github.com/jkachmar/lc2018
 -- |
--- | Code here is untouched from the section 'Exercise 4'
+-- | Code here is largely untouched from the section 'Exercise 4'
 
 module Example.Validation.Semigroup where
 
@@ -20,6 +20,9 @@ import Data.String.Regex.Flags (noFlags)
 import Data.Validation.Semigroup (V, invalid, unV)
 import Global.Unsafe (unsafeStringify)
 import Partial.Unsafe (unsafePartial)
+
+-- | A type synonym for purescript-validation semigroup errors
+type Errs = NonEmptyList InvalidPrimitive
 
 --------------------------------------------------------------------------------
 -- TYPES AND FUNCTIONS FOR FIELD VALIDATIONS

--- a/example/Validation/Utils.purs
+++ b/example/Validation/Utils.purs
@@ -1,0 +1,15 @@
+module Example.Validation.Utils where
+
+import Prelude
+
+import Data.Either (Either, either)
+import Data.Maybe (Maybe(..))
+
+-- | Unpacks errors to render as a string
+showError
+  :: ∀ e o r
+   . Show e
+  => { result :: Maybe (Either e o) | r }
+  -> Maybe String
+showError = join <<< map (either (Just <<< show) (const Nothing)) <<< _.result
+

--- a/example/basic/Component.purs
+++ b/example/basic/Component.purs
@@ -3,10 +3,9 @@ module Example.Basic.Component where
 import Prelude
 
 import Data.Const (Const)
-import Data.Either (Either(..), either)
+import Data.Either (either)
 import Data.Maybe (Maybe(..))
 import Data.Newtype (class Newtype, unwrap)
-import Data.String (null)
 import Data.Symbol (SProxy(..))
 import Effect.Aff (Aff)
 import Formless as Formless
@@ -33,14 +32,8 @@ derive instance newtypeForm :: Newtype (Form f) _
 
 formSpec :: Form FormSpec
 formSpec = Form
-  { name: FormSpec
-    { input: ""
-    , validator: \s -> if null s then Left "Too short" else Right s
-    }
-  , text: FormSpec
-    { input: ""
-    , validator: pure
-    }
+  { name: FormSpec ""
+  , text: FormSpec ""
   }
 
 _name = SProxy :: SProxy "name"

--- a/example/basic/Component.purs
+++ b/example/basic/Component.purs
@@ -73,6 +73,7 @@ component = H.parentComponent
         unit
         Formless.component
         { formSpec
+        , validator: pure
         , render: formless
         }
         (const Nothing)
@@ -86,7 +87,7 @@ component = H.parentComponent
 -- Formless
 
 formless
-  :: Formless.State Form
+  :: Formless.State Form Aff
   -> Formless.HTML Query (Const Void) Unit Form Aff
 formless state =
  HH.div_

--- a/example/basic/Component.purs
+++ b/example/basic/Component.purs
@@ -3,13 +3,13 @@ module Example.Basic.Component where
 import Prelude
 
 import Data.Const (Const)
-import Data.Either (either)
 import Data.List.NonEmpty (NonEmptyList)
 import Data.Maybe (Maybe(..))
 import Data.Newtype (class Newtype, unwrap)
 import Data.Symbol (SProxy(..))
 import Effect.Aff (Aff)
 import Example.Validation.Semigroup (InvalidPrimitive, validateNonEmpty)
+import Example.Validation.Utils (showError)
 import Formless as Formless
 import Formless.Spec (FormSpec, InputField, mkFormSpec)
 import Formless.Validation (onInputField)
@@ -105,7 +105,7 @@ formless state =
    [ FormField.field_
      { label: "Name"
      , helpText: Just $ "Write your name." <> (if name.touched then " (touched)" else "")
-     , error: join $ map (either (Just <<< show) (const Nothing)) name.result
+     , error: showError name
      , inputId: "name"
      }
      [ Input.input

--- a/example/basic/Component.purs
+++ b/example/basic/Component.purs
@@ -11,7 +11,7 @@ import Data.Symbol (SProxy(..))
 import Effect.Aff (Aff)
 import Example.Validation.Semigroup (InvalidPrimitive, validateNonEmpty)
 import Formless as Formless
-import Formless.Spec (FormSpec(..), InputField)
+import Formless.Spec (FormSpec, InputField, mkFormSpec)
 import Formless.Validation (onInputField)
 import Halogen as H
 import Halogen.HTML as HH
@@ -34,9 +34,9 @@ newtype Form f = Form
 derive instance newtypeForm :: Newtype (Form f) _
 
 formSpec :: Form FormSpec
-formSpec = Form
-  { name: FormSpec ""
-  , text: FormSpec ""
+formSpec = mkFormSpec
+  { name: ""
+  , text: ""
   }
 
 validator :: Form InputField -> Form InputField

--- a/example/external-components/Component.purs
+++ b/example/external-components/Component.purs
@@ -7,7 +7,7 @@ import Data.Maybe (Maybe(..))
 import Debug.Trace (spy)
 import Effect.Aff (Aff)
 import Example.ExternalComponents.RenderForm (formless)
-import Example.ExternalComponents.Spec (_email, _language, _whiskey, formSpec)
+import Example.ExternalComponents.Spec (_email, _language, _whiskey, formSpec, formValidation)
 import Example.ExternalComponents.Types (ChildQuery, ChildSlot, Query(..), Slot(..), State)
 import Formless as Formless
 import Halogen as H
@@ -53,7 +53,7 @@ component =
         unit
         Formless.component
         { formSpec
-        , validator: pure
+        , validator: pure <$> formValidation
         , render: formless
         }
         (HE.input HandleFormless)

--- a/example/external-components/Component.purs
+++ b/example/external-components/Component.purs
@@ -68,6 +68,13 @@ component =
       -- calling `eval`
       Formless.Emit q -> eval q *> pure a
 
+      -- When the form is validated, Formless will show the current status of all
+      -- fields and will report the total number of errors across fields. Only
+      -- validated fields report errors.
+      Formless.Validated form errors -> do
+        H.liftEffect $ Console.log $ "Validated! Errors: " <> show errors
+        pure a
+
       -- We'll just log the result here, but you could send this off to a server for
       -- processing on success.
       Formless.Submitted result -> case result of

--- a/example/external-components/Component.purs
+++ b/example/external-components/Component.purs
@@ -4,12 +4,13 @@ import Prelude
 
 import Data.Either (Either(..))
 import Data.Maybe (Maybe(..))
-import Debug.Trace (spy)
 import Effect.Aff (Aff)
+import Effect.Console (log) as Console
 import Example.ExternalComponents.RenderForm (formless)
-import Example.ExternalComponents.Spec (_email, _language, _whiskey, formSpec, formValidation)
+import Example.ExternalComponents.Spec (FormRow, _email, _language, _whiskey, formSpec, formValidation)
 import Example.ExternalComponents.Types (ChildQuery, ChildSlot, Query(..), Slot(..), State)
 import Formless as Formless
+import Formless.Spec as FSpec
 import Halogen as H
 import Halogen.HTML as HH
 import Halogen.HTML.Events as HE
@@ -71,10 +72,17 @@ component =
       -- processing on success.
       Formless.Submitted result -> case result of
         Left f -> do
-          let _ = spy "Failed to validate form." f
+          H.liftEffect $ Console.log "Failed to validate form."
           pure a
         Right v -> do
-          let _ = spy "Form is valid!" v
+          -- Now we have just a simple record of successful output!
+          let form :: Record (FormRow FSpec.Output)
+              form = FSpec.unwrapOutput v
+
+          H.liftEffect $ do
+             Console.log "Successfully validated form."
+             Console.log $ "Whiskey: " <> form.whiskey
+
           pure a
 
     HandleTypeahead slot m a -> case m of

--- a/example/external-components/Component.purs
+++ b/example/external-components/Component.purs
@@ -53,6 +53,7 @@ component =
         unit
         Formless.component
         { formSpec
+        , validator: pure
         , render: formless
         }
         (HE.input HandleFormless)

--- a/example/external-components/RenderForm.purs
+++ b/example/external-components/RenderForm.purs
@@ -2,12 +2,12 @@ module Example.ExternalComponents.RenderForm where
 
 import Prelude
 
-import Data.Either (either)
 import Data.Maybe (Maybe(..))
 import Data.Newtype (unwrap)
 import Effect.Aff (Aff)
 import Example.ExternalComponents.Spec (Form, _email, _name, _language, _whiskey)
 import Example.ExternalComponents.Types (FCQ, FCS, Query(..), Slot(..))
+import Example.Validation.Utils (showError)
 import Formless as Formless
 import Halogen as H
 import Halogen.HTML as HH
@@ -46,7 +46,7 @@ renderName state =
     [ FormField.field_
         { label: "Name"
         , helpText: Just "Write your name."
-        , error: join $ map (either Just (const Nothing)) field.result
+        , error: showError field
         , inputId: "name"
         }
         [ Input.input
@@ -66,7 +66,7 @@ renderEmail state =
     [ FormField.field_
         { label: "Email"
         , helpText: Just "Select an email address"
-        , error: join $ map (either Just (const Nothing)) field.result
+        , error: showError field
         , inputId: "email"
         }
         [ HH.slot
@@ -94,7 +94,7 @@ renderWhiskey state =
     [ FormField.field_
         { label: "Whiskey"
         , helpText: Just "Select a favorite whiskey"
-        , error: join $ map (either Just (const Nothing)) field.result
+        , error: showError field
         , inputId: "whiskey"
         }
         [ HH.slot
@@ -121,7 +121,7 @@ renderLanguage state =
     [ FormField.field_
         { label: "Language"
         , helpText: Just "Select a favorite language"
-        , error: join $ map (either Just (const Nothing)) field.result
+        , error: showError field
         , inputId: "language"
         }
         [ HH.slot

--- a/example/external-components/RenderForm.purs
+++ b/example/external-components/RenderForm.purs
@@ -15,7 +15,7 @@ import Halogen.HTML.Events as HE
 import Halogen.HTML.Properties as HP
 import Ocelot.Block.Button as Button
 import Ocelot.Block.FormField as FormField
-import Ocelot.Block.Input as Input
+import Ocelot.Block.Input (input) as Input
 import Ocelot.Components.Typeahead as TA
 import Ocelot.Components.Typeahead.Input as TA.Input
 import Record as Record

--- a/example/external-components/RenderForm.purs
+++ b/example/external-components/RenderForm.purs
@@ -23,7 +23,7 @@ import Record as Record
 -- | Our render function has access to anything in Formless' State type, plus
 -- | anything additional in your own state type.
 formless
-  :: Formless.State Form
+  :: Formless.State Form Aff
   -> Formless.HTML Query FCQ FCS Form Aff
 formless state =
   HH.div_
@@ -40,7 +40,7 @@ formless state =
 -- Helpers
 
 -- | A helper function to render a form text input
-renderName :: Formless.State Form -> Formless.HTML Query FCQ FCS Form Aff
+renderName :: Formless.State Form Aff -> Formless.HTML Query FCQ FCS Form Aff
 renderName state =
   HH.div_
     [ FormField.field_
@@ -60,7 +60,7 @@ renderName state =
   where
     field = unwrap $ Record.get _name $ unwrap state.form
 
-renderEmail :: Formless.State Form -> Formless.HTML Query FCQ FCS Form Aff
+renderEmail :: Formless.State Form Aff -> Formless.HTML Query FCQ FCS Form Aff
 renderEmail state =
   HH.div_
     [ FormField.field_
@@ -88,7 +88,7 @@ renderEmail state =
   where
     field = unwrap $ Record.get _email $ unwrap state.form
 
-renderWhiskey :: Formless.State Form -> Formless.HTML Query FCQ FCS Form Aff
+renderWhiskey :: Formless.State Form Aff -> Formless.HTML Query FCQ FCS Form Aff
 renderWhiskey state =
   HH.div_
     [ FormField.field_
@@ -115,7 +115,7 @@ renderWhiskey state =
   where
     field = unwrap $ Record.get _whiskey $ unwrap state.form
 
-renderLanguage :: Formless.State Form -> Formless.HTML Query FCQ FCS Form Aff
+renderLanguage :: Formless.State Form Aff -> Formless.HTML Query FCQ FCS Form Aff
 renderLanguage state =
   HH.div_
     [ FormField.field_

--- a/example/external-components/Spec.purs
+++ b/example/external-components/Spec.purs
@@ -2,11 +2,9 @@ module Example.ExternalComponents.Spec where
 
 import Prelude
 
-import Data.List.NonEmpty (singleton)
-import Data.Maybe (Maybe(..), fromMaybe)
+import Data.Maybe (Maybe, fromMaybe)
 import Data.Newtype (class Newtype)
 import Data.Symbol (SProxy(..))
-import Data.Validation.Semigroup (V, invalid)
 import Example.Validation.Semigroup as V
 import Formless.Spec as FSpec
 import Formless.Validation (onInputField)
@@ -44,13 +42,8 @@ formSpec = FSpec.mkFormSpecFromRow $ RProxy :: RProxy (FormRow FSpec.Input)
 formValidation :: Form FSpec.InputField -> Form FSpec.InputField
 formValidation (Form form) = Form
   { name: (\i -> V.validateNonEmpty i *> V.validateMinimumLength i 7) `onInputField` form.name
-  , email: (\i -> validateMaybe i *> V.validateEmailRegex (fromMaybe "" i)) `onInputField` form.email
-  , whiskey: validateMaybe `onInputField` form.whiskey
-  , language: validateMaybe `onInputField` form.language
+  , email: (\i -> V.validateMaybe i *> V.validateEmailRegex (fromMaybe "" i)) `onInputField` form.email
+  , whiskey: V.validateMaybe `onInputField` form.whiskey
+  , language: V.validateMaybe `onInputField` form.language
   }
-
--- | A custom validator that verifies a value is not Nothing
-validateMaybe :: ∀ a. Maybe a -> V V.Errs a
-validateMaybe Nothing = invalid (singleton V.EmptyField)
-validateMaybe (Just a) = pure a
 

--- a/example/external-components/Spec.purs
+++ b/example/external-components/Spec.purs
@@ -1,11 +1,7 @@
 module Example.ExternalComponents.Spec where
 
-import Prelude
-
-import Data.Either (Either(..))
 import Data.Maybe (Maybe(..))
 import Data.Newtype (class Newtype)
-import Data.String as String
 import Data.Symbol (SProxy(..))
 import Formless.Spec (FormSpec(..))
 
@@ -30,37 +26,8 @@ _language = SProxy :: SProxy "language"
 -- | separately.
 formSpec :: Form FormSpec
 formSpec = Form
-  { name: FormSpec
-      { input: ""
-      , validator: \str ->
-          if String.length str < 3
-            then Left "Must be 3 characters or more."
-            else Right str
-      }
-  , email: FormSpec
-      { input: Nothing
-      , validator: case _ of
-          Nothing -> Left "This field is required."
-          Just str -> if String.contains (String.Pattern "_") str
-            then Right str
-            else Left "Email addresses must have underscores."
-      }
-  , whiskey: FormSpec
-      { input: Nothing
-      , validator: case _ of
-          Nothing -> Left "This field is required."
-          Just str ->
-            if String.contains (String.Pattern "abel") str
-              then Right str
-              else Left "Only Kilchoman is allowed here!"
-      }
-  , language: FormSpec
-      { input: Nothing
-      , validator: case _ of
-          Nothing -> Left "This field is required."
-          Just str ->
-            if String.contains (String.Pattern "PHP") str
-              then Right str
-              else Left "Only PHP is allowed here!"
-      }
+  { name: FormSpec ""
+  , email: FormSpec Nothing
+  , whiskey: FormSpec Nothing
+  , language: FormSpec Nothing
   }

--- a/example/external-components/Spec.purs
+++ b/example/external-components/Spec.purs
@@ -2,12 +2,12 @@ module Example.ExternalComponents.Spec where
 
 import Prelude
 
-import Data.List.NonEmpty (NonEmptyList, singleton)
+import Data.List.NonEmpty (singleton)
 import Data.Maybe (Maybe(..), fromMaybe)
 import Data.Newtype (class Newtype)
 import Data.Symbol (SProxy(..))
 import Data.Validation.Semigroup (V, invalid)
-import Example.Validation.Semigroup (InvalidPrimitive(..), validateEmailRegex, validateMinimumLength, validateNonEmpty)
+import Example.Validation.Semigroup as V
 import Formless.Spec as FSpec
 import Formless.Validation (onInputField)
 import Type.Row (RProxy(..))
@@ -17,16 +17,13 @@ import Type.Row (RProxy(..))
 newtype Form f = Form (Record (FormRow f))
 derive instance newtypeForm :: Newtype (Form f) _
 
--- | A type synonym for purescript-validation semigroup errors
-type Errs = NonEmptyList InvalidPrimitive
-
 -- | We'll use this row to generate our form spec, but also to represent the
 -- | available fields in the record.
 type FormRow f =
-  ( name :: f String Errs String
-  , email :: f (Maybe String) Errs String
-  , whiskey :: f (Maybe String) Errs String
-  , language :: f (Maybe String) Errs String
+  ( name     :: f String         V.Errs String
+  , email    :: f (Maybe String) V.Errs String
+  , whiskey  :: f (Maybe String) V.Errs String
+  , language :: f (Maybe String) V.Errs String
   )
 
 -- | You'll usually want symbol proxies for convenience
@@ -46,14 +43,14 @@ formSpec = FSpec.mkFormSpecFromRow $ RProxy :: RProxy (FormRow FSpec.Input)
 -- | standard, `purescript-validation`.
 formValidation :: Form FSpec.InputField -> Form FSpec.InputField
 formValidation (Form form) = Form
-  { name: (\i -> validateNonEmpty i *> validateMinimumLength i 7) `onInputField` form.name
-  , email: (\i -> validateMaybe i *> validateEmailRegex (fromMaybe "" i)) `onInputField` form.email
+  { name: (\i -> V.validateNonEmpty i *> V.validateMinimumLength i 7) `onInputField` form.name
+  , email: (\i -> validateMaybe i *> V.validateEmailRegex (fromMaybe "" i)) `onInputField` form.email
   , whiskey: validateMaybe `onInputField` form.whiskey
   , language: validateMaybe `onInputField` form.language
   }
 
 -- | A custom validator that verifies a value is not Nothing
-validateMaybe :: ∀ a. Maybe a -> V Errs a
-validateMaybe Nothing = invalid (singleton EmptyField)
+validateMaybe :: ∀ a. Maybe a -> V V.Errs a
+validateMaybe Nothing = invalid (singleton V.EmptyField)
 validateMaybe (Just a) = pure a
 

--- a/example/external-components/Spec.purs
+++ b/example/external-components/Spec.purs
@@ -1,17 +1,26 @@
 module Example.ExternalComponents.Spec where
 
-import Data.Maybe (Maybe(..))
+import Prelude
+
+import Data.List.NonEmpty (NonEmptyList, singleton)
+import Data.Maybe (Maybe(..), fromMaybe)
 import Data.Newtype (class Newtype)
 import Data.Symbol (SProxy(..))
-import Formless.Spec (FormSpec(..))
+import Data.Validation.Semigroup (V, invalid)
+import Example.Validation.Semigroup (InvalidPrimitive(..), validateEmailRegex, validateMinimumLength, validateNonEmpty)
+import Formless.Spec (FormSpec(..), InputField)
+import Formless.Validation (onInputField)
+
+-- | A type synonym for purescript-validation semigroup errors
+type Errs = NonEmptyList InvalidPrimitive
 
 -- | Form inputs are expected to have this particular shape and rely
 -- | on the `InputField` type from Formless.
 newtype Form f = Form
-  { name :: f String String String
-  , email :: f (Maybe String) String String
-  , whiskey :: f (Maybe String) String String
-  , language :: f (Maybe String) String String
+  { name :: f String Errs String
+  , email :: f (Maybe String) Errs String
+  , whiskey :: f (Maybe String) Errs String
+  , language :: f (Maybe String) Errs String
   }
 derive instance newtypeForm :: Newtype (Form f) _
 
@@ -31,3 +40,19 @@ formSpec = Form
   , whiskey: FormSpec Nothing
   , language: FormSpec Nothing
   }
+
+-- | You should provide your own validation. This example uses the PureScript
+-- | standard, `purescript-validation`.
+formValidation :: Form InputField -> Form InputField
+formValidation (Form form) = Form
+  { name: (\i -> validateNonEmpty i *> validateMinimumLength i 7) `onInputField` form.name
+  , email: (\i -> validateMaybe i *> validateEmailRegex (fromMaybe "" i)) `onInputField` form.email
+  , whiskey: validateMaybe `onInputField` form.whiskey
+  , language: validateMaybe `onInputField` form.language
+  }
+
+-- | A custom validator that verifies a value is not Nothing
+validateMaybe :: ∀ a. Maybe a -> V Errs a
+validateMaybe Nothing = invalid (singleton EmptyField)
+validateMaybe (Just a) = pure a
+

--- a/example/external-components/Spec.purs
+++ b/example/external-components/Spec.purs
@@ -8,21 +8,26 @@ import Data.Newtype (class Newtype)
 import Data.Symbol (SProxy(..))
 import Data.Validation.Semigroup (V, invalid)
 import Example.Validation.Semigroup (InvalidPrimitive(..), validateEmailRegex, validateMinimumLength, validateNonEmpty)
-import Formless.Spec (FormSpec(..), InputField)
+import Formless.Spec as FSpec
 import Formless.Validation (onInputField)
+import Type.Row (RProxy(..))
+
+-- | You must provide a newtype around your form record in this format. Here,
+-- | rather than a record accepting `f`, we're just providing a row.
+newtype Form f = Form (Record (FormRow f))
+derive instance newtypeForm :: Newtype (Form f) _
 
 -- | A type synonym for purescript-validation semigroup errors
 type Errs = NonEmptyList InvalidPrimitive
 
--- | Form inputs are expected to have this particular shape and rely
--- | on the `InputField` type from Formless.
-newtype Form f = Form
-  { name :: f String Errs String
+-- | We'll use this row to generate our form spec, but also to represent the
+-- | available fields in the record.
+type FormRow f =
+  ( name :: f String Errs String
   , email :: f (Maybe String) Errs String
   , whiskey :: f (Maybe String) Errs String
   , language :: f (Maybe String) Errs String
-  }
-derive instance newtypeForm :: Newtype (Form f) _
+  )
 
 -- | You'll usually want symbol proxies for convenience
 _name = SProxy :: SProxy "name"
@@ -30,20 +35,16 @@ _email = SProxy :: SProxy "email"
 _whiskey = SProxy :: SProxy "whiskey"
 _language = SProxy :: SProxy "language"
 
--- | You are meant to provide a wrapper around `FormSpec` in order for
--- | this to all work out. Validators could be written (should be written)
--- | separately.
-formSpec :: Form FormSpec
-formSpec = Form
-  { name: FormSpec ""
-  , email: FormSpec Nothing
-  , whiskey: FormSpec Nothing
-  , language: FormSpec Nothing
-  }
+-- | mkFormSpecFromRow can produce a valid input form spec from your row
+-- | without you having to type anything. This is useful for especially
+-- | large forms where you don't want to have to stick newtypes everywhere.
+-- | If you already have a record of values, use `mkFormSpec` instead.
+formSpec :: Form FSpec.FormSpec
+formSpec = FSpec.mkFormSpecFromRow $ RProxy :: RProxy (FormRow FSpec.Input)
 
 -- | You should provide your own validation. This example uses the PureScript
 -- | standard, `purescript-validation`.
-formValidation :: Form InputField -> Form InputField
+formValidation :: Form FSpec.InputField -> Form FSpec.InputField
 formValidation (Form form) = Form
   { name: (\i -> validateNonEmpty i *> validateMinimumLength i 7) `onInputField` form.name
   , email: (\i -> validateMaybe i *> validateEmailRegex (fromMaybe "" i)) `onInputField` form.email

--- a/example/real-world/Component.purs
+++ b/example/real-world/Component.purs
@@ -1,0 +1,119 @@
+module Example.RealWorld.Component where
+
+import Prelude
+
+import Data.Either (Either(..))
+import Data.Maybe (Maybe(..))
+import Effect.Aff (Aff)
+import Effect.Console as Console
+import Example.RealWorld.Data.Group (GroupFormRow)
+import Example.RealWorld.Data.Options (OptionsRow)
+import Example.RealWorld.Render.GroupForm (render) as GroupForm
+import Example.RealWorld.Render.OptionsForm (render) as OptionsForm
+import Example.RealWorld.Spec.GroupForm (groupFormSpec, groupFormValidation)
+import Example.RealWorld.Spec.OptionsForm (optionsFormSpec, optionsFormValidation)
+import Example.RealWorld.Types (ChildQuery, ChildSlot, Query(..), State)
+import Formless as Formless
+import Formless.Spec as FSpec
+import Halogen as H
+import Halogen.Component.ChildPath as CP
+import Halogen.HTML as HH
+import Halogen.HTML.Events as HE
+import Ocelot.Block.Format as Format
+import Ocelot.Components.Typeahead as TA
+import Ocelot.HTML.Properties (css)
+
+component :: H.Component HH.HTML Query Unit Void Aff
+component =
+  H.parentComponent
+    { initialState: const unit
+    , render
+    , eval
+    , receiver: const Nothing
+    }
+  where
+
+  render :: State -> H.ParentHTML Query ChildQuery ChildSlot Aff
+  render st =
+    HH.div
+    [ css "flex-1 container p-12" ]
+    [ Format.heading_
+      [ HH.text "Formless" ]
+    , Format.subHeading_
+      [ HH.text "A form leveraging external components and custom form actions." ]
+    , Format.p_
+      [ HH.text $
+        "In Formless, you can freely leverage external components and embed them in the form. "
+        <> "This form shows how to use external typeaheads from the Ocelot design system from "
+        <> "CitizenNet. This form also demonstrates how you can manipulate forms in Formless. "
+        <> "Try selecting an email address, then a whiskey. You'll notice that changing your "
+        <> "whiskey selection also clears the selected email."
+      ]
+    , Format.p_
+      [ HH.text $
+        "Next, try opening the console. If you submit the form with invalid values, Formless will "
+        <> "show you your errors. If you submit a valid form, you'll see Formless just returns the "
+        <> "valid outputs for you to work with."
+      ]
+    , HH.slot'
+        CP.cp1
+        unit
+        Formless.component
+        { formSpec: groupFormSpec
+        , validator: pure <$> groupFormValidation
+        , render: GroupForm.render
+        }
+        (HE.input HandleGroupForm)
+    , HH.slot'
+        CP.cp2
+        unit
+        Formless.component
+        { formSpec: optionsFormSpec
+        , validator: pure <$> optionsFormValidation
+        , render: OptionsForm.render
+        }
+        (HE.input HandleOptionsForm)
+    ]
+
+  eval :: Query ~> H.ParentDSL State Query ChildQuery ChildSlot Void Aff
+  eval = case _ of
+    -- Always have to handle the `Emit` case
+    HandleGroupForm m a -> case m of
+      Formless.Emit q -> eval q *> pure a
+
+      Formless.Submitted result -> case result of
+        Left f -> do
+          H.liftEffect $ Console.log "Failed to validate form."
+          pure a
+        Right v -> do
+          -- Now we have just a simple record of successful output!
+          let form :: Record (GroupFormRow FSpec.Output)
+              form = FSpec.unwrapOutput v
+
+          H.liftEffect $ do
+             Console.log "Successfully validated form."
+             Console.log $ "Whiskey: " <> form.whiskey
+          pure a
+
+    HandleOptionsForm m a -> case m of
+      Formless.Emit q -> eval q *> pure a
+
+      Formless.Submitted result -> case result of
+        Left f -> do
+          H.liftEffect $ Console.log "Failed to validate form."
+          pure a
+        Right v -> do
+          -- Now we have just a simple record of successful output!
+          let form :: Record (OptionsRow FSpec.Output)
+              form = FSpec.unwrapOutput v
+
+          H.liftEffect $ do
+             Console.log "Successfully validated form."
+             Console.log $ "Enabled: " <> show form.enable
+          pure a
+
+    HandleTypeahead slot m a -> case m of
+      TA.Emit q -> eval q *> pure a
+      TA.SelectionsChanged s _ -> pure a
+      TA.VisibilityChanged _ -> pure a
+      TA.Searched _ -> pure a

--- a/example/real-world/Component.purs
+++ b/example/real-world/Component.purs
@@ -94,8 +94,8 @@ component =
   eval :: Query ~> H.ParentDSL State Query ChildQuery ChildSlot Void Aff
   eval = case _ of
 
-		-----
-		-- Parent
+  	-----
+  	-- Parent
 
     Select tab a -> do
       H.modify_ _ { focus = tab }
@@ -136,8 +136,8 @@ component =
 
     HandleGroupForm m a -> case m of
       Formless.Emit q -> eval q *> pure a
-			-- We are manually querying Formless to get form submissions
-			-- so we can safely ignore this.
+  		-- We are manually querying Formless to get form submissions
+  		-- so we can safely ignore this.
       Formless.Submitted _ -> pure a
 
       -- We don't care about the failed form result, but we do want

--- a/example/real-world/Component.purs
+++ b/example/real-world/Component.purs
@@ -94,8 +94,8 @@ component =
   eval :: Query ~> H.ParentDSL State Query ChildQuery ChildSlot Void Aff
   eval = case _ of
 
-  	-----
-  	-- Parent
+    -----
+    -- Parent
 
     Select tab a -> do
       H.modify_ _ { focus = tab }
@@ -136,8 +136,8 @@ component =
 
     HandleGroupForm m a -> case m of
       Formless.Emit q -> eval q *> pure a
-  		-- We are manually querying Formless to get form submissions
-  		-- so we can safely ignore this.
+      -- We are manually querying Formless to get form submissions
+      -- so we can safely ignore this.
       Formless.Submitted _ -> pure a
 
       -- We don't care about the failed form result, but we do want

--- a/example/real-world/Component.purs
+++ b/example/real-world/Component.purs
@@ -6,15 +6,14 @@ import Data.Either (Either(..))
 import Data.Maybe (Maybe(..))
 import Effect.Aff (Aff)
 import Effect.Console as Console
-import Example.RealWorld.Data.Group (_admin, _applications, _pixels, _whiskey)
+import Example.RealWorld.Data.Group (_admin, _applications, _pixels, _secretKey1, _secretKey2, _whiskey)
 import Example.RealWorld.Data.Options (_metric)
 import Example.RealWorld.Render.GroupForm as GroupForm
 import Example.RealWorld.Render.Nav as Nav
 import Example.RealWorld.Render.OptionsForm as OptionsForm
 import Example.RealWorld.Spec.GroupForm (groupFormSpec, groupFormValidation)
 import Example.RealWorld.Spec.OptionsForm (optionsFormSpec, optionsFormValidation)
-import Example.RealWorld.Types
-  (ChildQuery, ChildSlot, GroupTASlot(..), Query(..), State, Tab(..))
+import Example.RealWorld.Types (ChildQuery, ChildSlot, GroupTASlot(..), Query(..), State, Tab(..))
 import Formless as Formless
 import Halogen as H
 import Halogen.Component.ChildPath as CP
@@ -150,28 +149,39 @@ component =
       TA.Emit q -> eval q *> pure a
       TA.SelectionsChanged s v -> do
         let v' = TA.unpackSelections v
-        case s of
-          TA.ItemSelected x -> case slot of
-            ApplicationsTypeahead -> do
-              _ <- H.query' CP.cp1 unit $ Formless.handleChange _applications v'
-              _ <- H.query' CP.cp1 unit $ Formless.handleBlur _applications
-              pure a
-            PixelsTypeahead -> do
-              _ <- H.query' CP.cp1 unit $ Formless.handleChange _pixels v'
-              _ <- H.query' CP.cp1 unit $ Formless.handleBlur _pixels
-              pure a
-            WhiskeyTypeahead -> do
+        case slot of
+          ApplicationsTypeahead -> do
+            _ <- H.query' CP.cp1 unit $ Formless.handleChange _applications v'
+            _ <- H.query' CP.cp1 unit $ Formless.handleBlur _applications
+            pure a
+          PixelsTypeahead -> do
+            _ <- H.query' CP.cp1 unit $ Formless.handleChange _pixels v'
+            _ <- H.query' CP.cp1 unit $ Formless.handleBlur _pixels
+            pure a
+          WhiskeyTypeahead -> case s of
+            TA.ItemSelected x -> do
               _ <- H.query' CP.cp1 unit $ Formless.handleChange _whiskey (Just x)
               _ <- H.query' CP.cp1 unit $ Formless.handleBlur _whiskey
               pure a
-          _ -> pure a
+            _ -> do
+              _ <- H.query' CP.cp1 unit $ Formless.handleChange _whiskey Nothing
+              _ <- H.query' CP.cp1 unit $ Formless.handleBlur _whiskey
+              pure a
       TA.VisibilityChanged _ -> pure a
       TA.Searched _ -> pure a
 
     HandleAdminDropdown m a -> case m of
       Dropdown.ItemSelected x -> do
-        _ <- H.query' CP.cp1 unit $ Formless.handleChange _admin (Just x)
-        _ <- H.query' CP.cp1 unit $ Formless.handleBlur _admin
+        _ <- H.query' CP.cp1 unit
+          $ Formless.handleChange _admin (Just x)
+        _ <- H.query' CP.cp1 unit
+          $ Formless.handleBlur _admin
+
+        -- Changing this field should also clear the secret keys
+        _ <- H.query' CP.cp1 unit
+          $ Formless.handleChange _secretKey1 ""
+        _ <- H.query' CP.cp1 unit
+          $ Formless.handleChange _secretKey2 ""
         pure a
 
 

--- a/example/real-world/Component.purs
+++ b/example/real-world/Component.purs
@@ -21,6 +21,7 @@ import Halogen.Component.ChildPath as CP
 import Halogen.HTML as HH
 import Halogen.HTML.Events as HE
 import Ocelot.Block.Format as Format
+import Ocelot.Components.Dropdown (Message(..)) as Dropdown
 import Ocelot.Components.Typeahead as TA
 import Ocelot.HTML.Properties (css)
 
@@ -86,6 +87,9 @@ component =
       H.modify_ _ { focus = tab }
       pure a
 
+    -----
+    -- Group Form
+
     HandleGroupForm m a -> case m of
       Formless.Emit q -> eval q *> pure a
 
@@ -102,6 +106,19 @@ component =
              Console.log "Successfully validated form."
              Console.log $ "Whiskey: " <> form.whiskey
           pure a
+
+    HandleGroupTypeahead slot m a -> case m of
+      TA.Emit q -> eval q *> pure a
+      TA.SelectionsChanged s _ -> pure a
+      TA.VisibilityChanged _ -> pure a
+      TA.Searched _ -> pure a
+
+    HandleAdminDropdown m a -> case m of
+      Dropdown.ItemSelected x -> pure a
+
+
+    -----
+    -- Options Form
 
     HandleOptionsForm m a -> case m of
       Formless.Emit q -> eval q *> pure a
@@ -120,8 +137,9 @@ component =
              Console.log $ "Enabled: " <> show form.enable
           pure a
 
-    HandleTypeahead slot m a -> case m of
+    HandleOptionsTypeahead m a -> case m of
       TA.Emit q -> eval q *> pure a
       TA.SelectionsChanged s _ -> pure a
       TA.VisibilityChanged _ -> pure a
       TA.Searched _ -> pure a
+

--- a/example/real-world/Component.purs
+++ b/example/real-world/Component.purs
@@ -40,20 +40,20 @@ component =
     [ Format.heading_
       [ HH.text "Formless" ]
     , Format.subHeading_
-      [ HH.text "A form leveraging external components and custom form actions." ]
+      [ HH.text "A complex form inspired by real-world use cases." ]
     , Format.p_
       [ HH.text $
-        "In Formless, you can freely leverage external components and embed them in the form. "
-        <> "This form shows how to use external typeaheads from the Ocelot design system from "
-        <> "CitizenNet. This form also demonstrates how you can manipulate forms in Formless. "
-        <> "Try selecting an email address, then a whiskey. You'll notice that changing your "
-        <> "whiskey selection also clears the selected email."
+        "This component demonstrates building a large form with complex rendering and validation "
+        <> "requirements. Notice how both tabs end up unifying to a single output type after the "
+        <> "two forms are combined, how various dropdowns determine the contents (and visibility) "
+        <> "of other form elements, the assorted external components, and how validation for many "
+        <> "fields depends on the values of other fields in the form."
       ]
     , Format.p_
       [ HH.text $
-        "Next, try opening the console. If you submit the form with invalid values, Formless will "
-        <> "show you your errors. If you submit a valid form, you'll see Formless just returns the "
-        <> "valid outputs for you to work with."
+        "Next, review the source code. You'll notice that all of the complex types and state necessary "
+        <> "to run this form can be generated from a pair of row types. All that's left for you to handle "
+        <> "is to write the validation (with helper functions) and the render function."
       ]
     , HH.slot'
         CP.cp1

--- a/example/real-world/Data/Group.purs
+++ b/example/real-world/Data/Group.purs
@@ -55,8 +55,8 @@ type GroupRow f r =
   , admin        :: f (Maybe Admin)  Errs Admin
   , applications :: f (Array String) Errs (Array String)
   , pixels       :: f (Array String) Errs (Array String)
-  , maxBudget    :: f (Maybe String) Errs (Maybe Int)
-  , minBudget    :: f (Maybe String) Errs Int
+  , maxBudget    :: f String         Errs (Maybe Int)
+  , minBudget    :: f String         Errs Int
   , whiskey      :: f (Maybe String) Errs String
   | r
   )

--- a/example/real-world/Data/Group.purs
+++ b/example/real-world/Data/Group.purs
@@ -87,7 +87,7 @@ newtype Group = Group
     ( GroupRow FSpec.Output
       ( id :: GroupId
       , secretKey :: String
-      , options :: Options
+      , options :: Maybe Options
       )
     )
   )

--- a/example/real-world/Data/Group.purs
+++ b/example/real-world/Data/Group.purs
@@ -1,0 +1,114 @@
+-- | A data type representing some large object that will need to be
+-- | parsed from a form and sent to a database via JSON. Similarly,
+-- | loading up a form ought to load the last-saved values for each
+-- | field and hydrate them.
+module Example.RealWorld.Data.Group where
+
+import Prelude
+
+import Data.Maybe (Maybe)
+import Data.Newtype (class Newtype)
+import Data.Symbol (SProxy(..))
+import Example.RealWorld.Data.Options (Options)
+import Example.Validation.Semigroup (Errs)
+import Formless.Spec as FSpec
+
+-----
+-- A custom ID type
+
+newtype GroupId = GroupId Int
+derive instance newtypeFBGroupId :: Newtype GroupId _
+derive newtype instance eqGroupId :: Eq GroupId
+derive newtype instance showGroupId :: Show GroupId
+
+-----
+-- A nested field type
+
+newtype Admin = Admin { id :: Maybe GroupId }
+derive instance newtypeAdmin :: Newtype Admin _
+derive newtype instance eqAdmin :: Eq Admin
+derive newtype instance showAdmin :: Show Admin
+
+-----
+-- Our primary data type
+
+-- | We'll define our data type as an extensible row. This represents all
+-- | the fields that will be shared between our Form data type and our
+-- | resulting Group data type.
+-- |
+-- | Next, we'll define both data types by extending this row in various
+-- | ways. The Group type has an ID key and an options object that the form
+-- | won't know about when being filled out. And the Form will have two
+-- | secret key fields (one for confirmation) whereas the Group type will
+-- | have only one, and of a different name altogether.
+-- |
+-- | In order to be able to define a form, you'll need to leave a type variable
+-- | free that takes 3 types as arguments: the input (what the user provides),
+-- | error type (produced by validation), and output (what results from
+-- | successful validation).
+-- |
+-- | In order for this row to be extensible, you'll need another type variable open
+-- | to take possible additional rows
+-- |                  Input          Error Output
+type GroupRow f r =
+  ( name         :: f String         Errs String
+  , admin        :: f (Maybe Admin)  Errs Admin
+  , applications :: f (Array String) Errs (Array String)
+  , pixels       :: f (Array String) Errs (Array String)
+  , maxBudget    :: f (Maybe Int)    Errs (Maybe Int)
+  , minBudget    :: f (Maybe Int)    Errs Int
+  , whiskey      :: f (Maybe String) Errs String
+  | r
+  )
+
+-- | We'll define proxies for convenience so we can refer to these fields via
+-- | lenses and other sorts of things.
+_name = SProxy :: SProxy "name"
+_admin = SProxy :: SProxy "admin"
+_applications = SProxy :: SProxy "applications"
+_pixels = SProxy :: SProxy "pixels"
+_maxBudget = SProxy :: SProxy "maxBudget"
+_minBudget = SProxy :: SProxy "minBudget"
+_whiskey = SProxy :: SProxy "whiskey"
+
+-- | Here's the Group data type we'll use throughout our application. After we send
+-- | a form result off to the server, this is what we'll get in return on
+-- | subsequent form edits.
+-- |
+-- | Note that we're using the same GroupRow type, but we're filling in `f` with the
+-- | Output type provided in the row (the third type on each line), and we're
+-- | providing a few new rows.
+-- |
+-- | Also note that the Group data type relies on another form -- the Options type
+-- | from the Options form. With this sort of nesting, we'll use two instances of
+-- | Formless.
+newtype Group = Group
+  ( Record
+    ( GroupRow FSpec.Output
+      ( id :: GroupId
+      , secretKey :: String
+      , options :: Options
+      )
+    )
+  )
+derive instance newtypeGroup :: Newtype Group _
+
+_id = SProxy :: SProxy "id"
+_secretKey = SProxy :: SProxy "secretKey"
+_options = SProxy :: SProxy "options"
+
+-- | Here's the Form type we'll use to run with Formless. Again most of the fields are
+-- | the same, but just like the Group data type we'll add a few more rows. Unlike that
+-- | data type, we need to leave the `f` free for Formless to leverage.
+newtype GroupForm f = GroupForm (Record (GroupFormRow f))
+derive instance newtypeGroupForm :: Newtype (GroupForm f) _
+
+-- | In order to generate our fields automatically using mkFormSpecFromRow, we'll make
+-- | sure to have the new row as a new type.
+type GroupFormRow f = GroupRow f
+  ( secretKey1 :: f String Errs String
+  , secretKey2 :: f String Errs String
+  )
+
+_secretKey1 = SProxy :: SProxy "secretKey1"
+_secretKey2 = SProxy :: SProxy "secretKey2"

--- a/example/real-world/Data/Group.purs
+++ b/example/real-world/Data/Group.purs
@@ -55,8 +55,8 @@ type GroupRow f r =
   , admin        :: f (Maybe Admin)  Errs Admin
   , applications :: f (Array String) Errs (Array String)
   , pixels       :: f (Array String) Errs (Array String)
-  , maxBudget    :: f (Maybe Int)    Errs (Maybe Int)
-  , minBudget    :: f (Maybe Int)    Errs Int
+  , maxBudget    :: f (Maybe String) Errs (Maybe Int)
+  , minBudget    :: f (Maybe String) Errs Int
   , whiskey      :: f (Maybe String) Errs String
   | r
   )

--- a/example/real-world/Data/Options.purs
+++ b/example/real-world/Data/Options.purs
@@ -13,6 +13,7 @@ import Data.Newtype (class Newtype)
 import Data.String.Read (class Read)
 import Data.Symbol (SProxy(..))
 import Example.Validation.Semigroup (Errs)
+import Formless.Class.Initial (class Initial)
 import Formless.Spec as FSpec
 
 -----
@@ -33,6 +34,7 @@ data Metric
 derive instance genericMetric :: Generic Metric _
 derive instance eqMetric :: Eq Metric
 derive instance ordMetric :: Ord Metric
+
 instance showMetric :: Show Metric where
   show = genericShow
 
@@ -42,6 +44,23 @@ instance readMetric :: Read Metric where
   read "InstallCost" = Just InstallCost
   read _ = Nothing
 
+-- | This data type will be used in radio buttons, and so if we
+-- | want to generate an initial form from our row, we'll need an
+-- | instance of the Initial type class
+data Speed
+  = Low
+  | Medium
+  | Fast
+derive instance genericSpeed :: Generic Speed _
+derive instance eqSpeed :: Eq Speed
+derive instance ordSpeed :: Ord Speed
+
+instance showSpeed :: Show Speed where
+  show = genericShow
+
+instance initialSpeed :: Initial Speed where
+  initial = Low
+
 -----
 -- Our primary data type
 
@@ -50,13 +69,14 @@ instance readMetric :: Read Metric where
 -- | closed row. In the case of the 'enable' option, we know there's no validation
 -- | for it, so we'll use `Void` as the error type.
 type OptionsRow f =
-  ( enable       :: f Boolean        Void  Boolean
+  ( enable       :: f Boolean        Void Boolean
   , metric       :: f (Maybe String) Errs Metric
   , viewCost     :: f String         Errs (Maybe Dollars)
   , clickCost    :: f String         Errs (Maybe Dollars)
   , installCost  :: f String         Errs (Maybe Dollars)
   , size         :: f String         Errs Number
   , dimensions   :: f String         Errs Number
+  , speed        :: f Speed          Void Speed
   )
 
 _enable = SProxy :: SProxy "enable"

--- a/example/real-world/Data/Options.purs
+++ b/example/real-world/Data/Options.purs
@@ -70,7 +70,7 @@ instance initialSpeed :: Initial Speed where
 -- | for it, so we'll use `Void` as the error type.
 type OptionsRow f =
   ( enable       :: f Boolean        Void Boolean
-  , metric       :: f (Maybe Metric) Void Metric
+  , metric       :: f (Maybe Metric) Errs Metric
   , viewCost     :: f String         Errs (Maybe Dollars)
   , clickCost    :: f String         Errs (Maybe Dollars)
   , installCost  :: f String         Errs (Maybe Dollars)

--- a/example/real-world/Data/Options.purs
+++ b/example/real-world/Data/Options.purs
@@ -1,0 +1,78 @@
+-- | A data type representing some large object that will need to be
+-- | parsed from a form and sent to a database via JSON. Similarly,
+-- | loading up a form ought to load the last-saved values for each
+-- | field and hydrate them.
+module Example.RealWorld.Data.Options where
+
+import Prelude
+
+import Data.Generic.Rep (class Generic)
+import Data.Generic.Rep.Show (genericShow)
+import Data.Maybe (Maybe(..))
+import Data.Newtype (class Newtype)
+import Data.String.Read (class Read)
+import Data.Symbol (SProxy(..))
+import Example.Validation.Semigroup (Errs)
+import Formless.Spec as FSpec
+
+-----
+-- Some custom data
+
+-- | This data type represents dollar amounts
+newtype Dollars = Dollars Int
+derive instance newtypeDollars :: Newtype Dollars _
+
+-- | This data type represents different metrics a user
+-- | can choose from. Depending on what metric they choose,
+-- | only fields relevant to that metric ought to render in
+-- | the form.
+data Metric
+  = ViewCost
+  | ClickCost
+  | InstallCost
+derive instance genericMetric :: Generic Metric _
+derive instance eqMetric :: Eq Metric
+derive instance ordMetric :: Ord Metric
+instance showMetric :: Show Metric where
+  show = genericShow
+
+instance readMetric :: Read Metric where
+  read "ViewCost" = Just ViewCost
+  read "ClickCost" = Just ClickCost
+  read "InstallCost" = Just InstallCost
+  read _ = Nothing
+
+-----
+-- Our primary data type
+
+-- | Just like the Group data type, we'll use a row as our underlying type. However,
+-- | since we don't have to extend this with any fields, we can stick with a simpler
+-- | closed row. In the case of the 'enable' option, we know there's no validation
+-- | for it, so we'll use `Void` as the error type.
+type OptionsRow f =
+  ( enable       :: f Boolean        Void  Boolean
+  , metric       :: f (Maybe String) Errs Metric
+  , viewCost     :: f String         Errs (Maybe Dollars)
+  , clickCost    :: f String         Errs (Maybe Dollars)
+  , installCost  :: f String         Errs (Maybe Dollars)
+  , size         :: f String         Errs Number
+  , dimensions   :: f String         Errs Number
+  )
+
+_enable = SProxy :: SProxy "enable"
+_metric = SProxy :: SProxy "metric"
+_viewCost = SProxy :: SProxy "viewCost"
+_clickCost = SProxy :: SProxy "clickCost"
+_installCost = SProxy :: SProxy "installCost"
+_size = SProxy :: SProxy "size"
+_dimensions = SProxy :: SProxy "dimensions"
+
+-- | This is the data type used throughout the application. In this case, it's the same
+-- | as the form and the underlying row.
+newtype Options = Options (Record (OptionsRow FSpec.Output))
+derive instance newtypeOptions :: Newtype Options _
+
+-- | Here's the Form type we'll use to run with Formless. The fields are the same as the
+-- | underlying row.
+newtype OptionsForm f = OptionsForm (Record (OptionsRow f))
+derive instance newtypeOptionsForm :: Newtype (OptionsForm f) _

--- a/example/real-world/Data/Options.purs
+++ b/example/real-world/Data/Options.purs
@@ -70,7 +70,7 @@ instance initialSpeed :: Initial Speed where
 -- | for it, so we'll use `Void` as the error type.
 type OptionsRow f =
   ( enable       :: f Boolean        Void Boolean
-  , metric       :: f (Maybe String) Errs Metric
+  , metric       :: f (Maybe Metric) Void Metric
   , viewCost     :: f String         Errs (Maybe Dollars)
   , clickCost    :: f String         Errs (Maybe Dollars)
   , installCost  :: f String         Errs (Maybe Dollars)
@@ -86,6 +86,7 @@ _clickCost = SProxy :: SProxy "clickCost"
 _installCost = SProxy :: SProxy "installCost"
 _size = SProxy :: SProxy "size"
 _dimensions = SProxy :: SProxy "dimensions"
+_speed = SProxy :: SProxy "speed"
 
 -- | This is the data type used throughout the application. In this case, it's the same
 -- | as the form and the underlying row.

--- a/example/real-world/Render/Field.purs
+++ b/example/real-world/Render/Field.purs
@@ -30,25 +30,36 @@ type FieldConfig sym =
 -----
 -- Common field rendering
 
-text
+data FieldType
+  = Currency
+  | Percentage
+  | Text
+
+input
   :: ∀ form sym e o t0 fields m pq cq cs
    . IsSymbol sym
   => Show e
   => Newtype (form InputField) (Record fields)
   => Cons sym (InputField String e o) t0 fields
   => FieldConfig sym
+  -> FieldType
   -> Formless.State form m
   -> Formless.HTML pq cq cs form m
-text config state =
+input config ft state =
   HH.div_
     [ formField state config $ \field ->
-        Input.input
-          [ HP.placeholder $ fromMaybe "" config.placeholder
-          , HP.value field.input
-          , Formless.onBlurWith config.field
-          , Formless.onValueInputWith config.field
-          ]
+        case ft of
+          Text -> Input.input (props field)
+          Currency -> Input.currency_ (props field)
+          Percentage -> Input.percentage_ (props field)
     ]
+  where
+    props field =
+      [ HP.placeholder $ fromMaybe "" config.placeholder
+      , HP.value field.input
+      , Formless.onBlurWith config.field
+      , Formless.onValueInputWith config.field
+      ]
 
 
 -- | A utility to help create form fields using an unwrapped

--- a/example/real-world/Render/Field.purs
+++ b/example/real-world/Render/Field.purs
@@ -1,0 +1,49 @@
+module Example.RealWorld.Render.Field where
+
+import Prelude
+
+import Data.Maybe (Maybe(..), fromMaybe)
+import Data.Newtype (class Newtype, unwrap)
+import Data.String (toLower) as String
+import Data.Symbol (class IsSymbol, SProxy)
+import Example.Validation.Utils (showError)
+import Formless as Formless
+import Formless.Spec (InputField)
+import Halogen.HTML as HH
+import Halogen.HTML.Properties as HP
+import Ocelot.Block.FormField as FormField
+import Ocelot.Block.Input as Input
+import Prim.Row (class Cons)
+import Record as Record
+
+-----
+-- Common field rendering
+
+text
+  :: ∀ form sym e o t0 fields m pq cq cs
+   . IsSymbol sym
+  => Show e
+  => Newtype (form InputField) (Record fields)
+  => Cons sym (InputField String e o) t0 fields
+  => { label :: String, helpText :: String, placeholder :: Maybe String, field :: SProxy sym }
+  -> Formless.State form m
+  -> Formless.HTML pq cq cs form m
+text config state =
+  HH.div_
+    [ FormField.field_
+        { label: config.label
+        , helpText: Just config.helpText
+        , error: showError field
+        , inputId: String.toLower config.label
+        }
+        [ Input.input
+          [ HP.placeholder $ fromMaybe "" config.placeholder
+          , HP.value field.input
+          , Formless.onBlurWith config.field
+          , Formless.onValueInputWith config.field
+          ]
+        ]
+    ]
+  where
+    field = unwrap $ Record.get config.field $ unwrap state.form
+

--- a/example/real-world/Render/GroupForm.purs
+++ b/example/real-world/Render/GroupForm.purs
@@ -6,23 +6,24 @@ import Data.Maybe (Maybe(..), fromMaybe, maybe)
 import Data.Newtype (class Newtype, unwrap)
 import Data.Symbol (class IsSymbol)
 import Effect.Aff (Aff)
-import Example.RealWorld.Data.Group (Admin(..), GroupId(..), _maxBudget, _minBudget)
+import Example.RealWorld.Data.Group
+  (Admin(..), GroupId(..), _maxBudget, _minBudget)
 import Example.RealWorld.Data.Group as G
 import Example.RealWorld.Render.Field (FieldConfig)
-import Example.RealWorld.Render.Field (formField, text) as Field
+import Example.RealWorld.Render.Field as Field
 import Example.RealWorld.Types (GroupCQ, GroupCS, GroupTASlot(..), Query(..))
 import Formless as Formless
 import Formless.Spec (InputField)
 import Halogen as H
-import Halogen.Component.ChildPath (cp1, cp2) as CP
+import Halogen.Component.ChildPath as CP
 import Halogen.HTML as HH
 import Halogen.HTML.Events as HE
 import Halogen.HTML.Properties as HP
-import Ocelot.Block.Card (card_) as Card
-import Ocelot.Block.Format (subHeading_) as Format
-import Ocelot.Block.Input (percentage_) as Input
-import Ocelot.Block.Range (range) as Range
-import Ocelot.Components.Dropdown (dropdown) as Dropdown
+import Ocelot.Block.Card as Card
+import Ocelot.Block.Format as Format
+import Ocelot.Block.Input as Input
+import Ocelot.Block.Range as Range
+import Ocelot.Components.Dropdown as Dropdown
 import Ocelot.Components.Typeahead as TA
 import Ocelot.Components.Typeahead.Input as TA.Input
 import Ocelot.HTML.Properties (css)
@@ -68,30 +69,30 @@ render state =
 
 renderName :: FormlessState -> FormlessHTML
 renderName =
-  Field.text
+  Field.input
   { label: "Name"
   , placeholder: Just "January Cohort"
   , helpText: "Give the group a name."
   , field: G._name
-  }
+  } Field.Text
 
 renderSecretKey1 :: FormlessState -> FormlessHTML
 renderSecretKey1 =
-  Field.text
+  Field.input
   { label: "Secret Key"
   , placeholder: Just "au,#OK#F48i$"
   , helpText: "Give the group a secret identifier"
   , field: G._secretKey1
-  }
+  } Field.Text
 
 renderSecretKey2 :: FormlessState -> FormlessHTML
 renderSecretKey2 =
-  Field.text
+  Field.input
   { label: "Secret Key (Confirm)"
   , placeholder: Just "au,#OK#F48i$"
   , helpText: "Enter the same secret identifier to confirm."
   , field: G._secretKey2
-  }
+  } Field.Text
 
 renderAdmin :: FormlessState -> FormlessHTML
 renderAdmin state =

--- a/example/real-world/Render/GroupForm.purs
+++ b/example/real-world/Render/GroupForm.purs
@@ -1,22 +1,264 @@
 module Example.RealWorld.Render.GroupForm where
 
-import Data.Maybe (Maybe(..))
-import Effect.Aff (Aff)
-import Example.RealWorld.Data.Group as G
-import Example.RealWorld.Render.Field (text) as Field
-import Example.RealWorld.Types (GroupCQ, Query, GroupCS)
-import Formless as Formless
-import Halogen.HTML as HH
+import Prelude
 
-render
-  :: Formless.State G.GroupForm Aff
-  -> Formless.HTML Query GroupCQ GroupCS G.GroupForm Aff
+import Data.Maybe (Maybe(..), fromMaybe, maybe)
+import Data.Newtype (class Newtype, unwrap)
+import Data.Symbol (class IsSymbol)
+import Effect.Aff (Aff)
+import Example.RealWorld.Data.Group (Admin(..), GroupId(..), _maxBudget, _minBudget)
+import Example.RealWorld.Data.Group as G
+import Example.RealWorld.Render.Field (FieldConfig)
+import Example.RealWorld.Render.Field (formField, text) as Field
+import Example.RealWorld.Types (GroupCQ, GroupCS, GroupTASlot(..), Query(..))
+import Formless as Formless
+import Formless.Spec (InputField)
+import Halogen as H
+import Halogen.Component.ChildPath (cp1, cp2) as CP
+import Halogen.HTML as HH
+import Halogen.HTML.Events as HE
+import Halogen.HTML.Properties as HP
+import Ocelot.Block.Card (card_) as Card
+import Ocelot.Block.Format (subHeading_) as Format
+import Ocelot.Block.Input (percentage_) as Input
+import Ocelot.Block.Range (range) as Range
+import Ocelot.Components.Dropdown (dropdown) as Dropdown
+import Ocelot.Components.Typeahead as TA
+import Ocelot.Components.Typeahead.Input as TA.Input
+import Ocelot.HTML.Properties (css)
+import Prim.Row (class Cons)
+import Record (get) as Record
+
+type FormlessState
+  = Formless.State G.GroupForm Aff
+
+type FormlessHTML
+  = Formless.HTML Query GroupCQ GroupCS G.GroupForm Aff
+
+render :: FormlessState -> FormlessHTML
 render state =
   HH.div_
-    [ Field.text
-      { label: "A text field"
-      , placeholder: Just "Fill me in"
-      , helpText: "I exist on the group form."
-      , field: G._name
-      } state
+    [ Card.card_
+      [ Format.subHeading_
+        [ HH.text "Name & Admin" ]
+      , renderName state
+      , renderAdmin state
+      , renderSecretKey1 state
+      , renderSecretKey2 state
+      ]
+    , Card.card_
+      [ Format.subHeading_
+        [ HH.text "Applications & Pixels" ]
+      , renderApplications state
+      , renderPixels state
+      , renderWhiskey state
+      ]
+    , Card.card_
+      [ Format.subHeading_
+        [ HH.text "Min & Max Budget" ]
+      , renderMinMaxBudget state
+      ]
     ]
+
+
+
+-----
+-- Built fields
+
+renderMinMaxBudget :: FormlessState -> FormlessHTML
+renderMinMaxBudget state =
+  HH.div
+    [ css "flex items-center" ]
+    [ HH.label
+        [ css "flex-1 block text-center" ]
+        [ HH.div
+            [ css "py-3" ]
+            [ HH.text "Max Budget (Optional)" ]
+        , Input.percentage_
+            [ Formless.onBlurWith _minBudget
+            , HP.value $ fromMaybe "" minBudget.input
+            ]
+        ]
+    , Range.range
+        [ css "px-4 flex-4 self-end my-5"
+        , HP.min 0.0
+        , HP.max 100.0
+        --  , HE.onValueChange $ Formless.handleChange _minBudget
+        , HP.value $ fromMaybe "0.0" minBudget.input
+        ]
+    , HH.label
+        [ css "flex-1 block text-center" ]
+        [ HH.div
+            [ css "py-3" ]
+            [ HH.text "Max Budget (Optional)"
+            , Input.percentage_
+                [ Formless.onBlurWith _maxBudget
+                , HP.value $ fromMaybe "" maxBudget.input
+                ]
+            ]
+        ]
+    ]
+  where
+    minBudget = unwrap $ Record.get _minBudget $ unwrap state.form
+    maxBudget = unwrap $ Record.get _maxBudget $ unwrap state.form
+
+renderApplications :: FormlessState -> FormlessHTML
+renderApplications =
+ multiTypeahead
+   ApplicationsTypeahead
+   HandleGroupTypeahead
+   { label: "Applications"
+   , placeholder: Just "Facebook"
+   , helpText: "Select one or more applications for the group."
+   , field: G._name
+   }
+   [ "Facebook", "Google", "Twitter", "Pinterest" ]
+
+renderPixels :: FormlessState -> FormlessHTML
+renderPixels =
+  multiTypeahead
+    PixelsTypeahead
+    HandleGroupTypeahead
+    { label: "Pixels"
+    , placeholder: Just "My unique pixel"
+    , helpText: "Select one or more tracking pixels for the group."
+    , field: G._name
+    }
+    [ "My favorite pixel"
+    , "Your favorite pixel"
+    , "Application main pixel"
+    , "A pixel for you is a pixel for me"
+    ]
+
+renderWhiskey :: FormlessState -> FormlessHTML
+renderWhiskey state =
+  HH.div_
+    [ Field.formField state
+      { label: "Whiskey"
+      , placeholder: Nothing
+      , helpText: "Select one whiskey you'd like in the group."
+      , field: G._whiskey
+      }
+      $ \whiskey ->
+        HH.slot'
+          CP.cp1
+          WhiskeyTypeahead
+          TA.component
+          ( TA.Input.defSingle
+            [ HP.placeholder "Hakushu" ]
+            [ "Laphroiag 10"
+            , "Lagavulin 12"
+            , "Lagavulin 16"
+            , "Oban 16"
+            , "Kilchoman Blue Label"
+            ]
+            TA.Input.renderItemString
+          )
+          ( HE.input ( Formless.Raise
+                       <<< H.action
+                       <<< HandleGroupTypeahead WhiskeyTypeahead
+                      )
+          )
+    ]
+
+renderAdmin :: FormlessState -> FormlessHTML
+renderAdmin state =
+  HH.div_
+    [ Field.formField state
+      { label: "Admin (Optional)"
+      , placeholder: Nothing
+      , helpText: "Choose an admin id to include."
+      , field: G._admin
+      }
+      \admin ->
+        HH.slot'
+          CP.cp2
+          unit
+          Dropdown.dropdown
+          { selectedItem: Nothing
+          , items
+          , label: "Select an admin"
+          , toString: \(Admin { id }) -> maybe "None" show id
+          , disabled: false
+          }
+          ( HE.input
+            ( Formless.Raise
+              <<< H.action
+              <<< HandleAdminDropdown
+            )
+          )
+    ]
+
+  where
+    items =
+      [ Admin { id: Nothing }
+      , Admin { id: Just $ GroupId 10 }
+      , Admin { id: Just $ GroupId 15 }
+      , Admin { id: Just $ GroupId 20 }
+      , Admin { id: Just $ GroupId 25 }
+      , Admin { id: Just $ GroupId 30 }
+      , Admin { id: Just $ GroupId 35 }
+      ]
+
+renderSecretKey2 :: FormlessState -> FormlessHTML
+renderSecretKey2 =
+  Field.text
+  { label: "Secret Key (Confirm)"
+  , placeholder: Just "au,#OK#F48i$"
+  , helpText: "Enter the same secret identifier to confirm."
+  , field: G._secretKey2
+  }
+
+renderSecretKey1 :: FormlessState -> FormlessHTML
+renderSecretKey1 =
+  Field.text
+  { label: "Secret Key"
+  , placeholder: Just "au,#OK#F48i$"
+  , helpText: "Give the group a secret identifier"
+  , field: G._secretKey1
+  }
+
+renderName :: FormlessState -> FormlessHTML
+renderName =
+  Field.text
+  { label: "Name"
+  , placeholder: Just "January Cohort"
+  , helpText: "Give the group a name."
+  , field: G._name
+  }
+
+-----
+-- Helper functions
+
+data Amount
+  = Single
+  | Multi
+derive instance eqAmount :: Eq Amount
+
+multiTypeahead
+  :: ∀ sym e o t0 fields
+   . IsSymbol sym
+  => Show e
+  => Newtype (G.GroupForm InputField) (Record fields)
+  => Cons sym (InputField String e o) t0 fields
+  => GroupTASlot
+  -> (GroupTASlot -> TA.Message Query String -> Unit -> Query Unit)
+  -> FieldConfig sym
+  -> Array String
+  -> FormlessState
+  -> FormlessHTML
+multiTypeahead slot query config items state =
+  HH.div_
+    [ Field.formField state config $ \field ->
+        HH.slot'
+          CP.cp1
+          slot
+          TA.component
+          ( TA.Input.defMulti
+            [ HP.placeholder $ fromMaybe "" config.placeholder ]
+            items
+            TA.Input.renderItemString
+          )
+          ( HE.input (Formless.Raise <<< H.action <<< query slot) )
+    ]
+

--- a/example/real-world/Render/GroupForm.purs
+++ b/example/real-world/Render/GroupForm.purs
@@ -1,13 +1,22 @@
 module Example.RealWorld.Render.GroupForm where
 
+import Data.Maybe (Maybe(..))
 import Effect.Aff (Aff)
-import Example.RealWorld.Data.Group (GroupForm)
+import Example.RealWorld.Data.Group as G
+import Example.RealWorld.Render.Field (text) as Field
 import Example.RealWorld.Types (GroupCQ, Query, GroupCS)
 import Formless as Formless
 import Halogen.HTML as HH
 
 render
-  :: Formless.State GroupForm Aff
-  -> Formless.HTML Query GroupCQ GroupCS GroupForm Aff
+  :: Formless.State G.GroupForm Aff
+  -> Formless.HTML Query GroupCQ GroupCS G.GroupForm Aff
 render state =
-  HH.div_ [ HH.text "I am the group form." ]
+  HH.div_
+    [ Field.text
+      { label: "A text field"
+      , placeholder: Just "Fill me in"
+      , helpText: "I exist on the group form."
+      , field: G._name
+      } state
+    ]

--- a/example/real-world/Render/GroupForm.purs
+++ b/example/real-world/Render/GroupForm.purs
@@ -11,7 +11,8 @@ import Example.RealWorld.Data.Group
 import Example.RealWorld.Data.Group as G
 import Example.RealWorld.Render.Field (FieldConfig)
 import Example.RealWorld.Render.Field as Field
-import Example.RealWorld.Types (GroupCQ, GroupCS, GroupTASlot(..), Query(..))
+import Example.RealWorld.Types
+  (GroupCQ, GroupCS, GroupTASlot(..), Query(..))
 import Formless as Formless
 import Formless.Spec (InputField)
 import Halogen as H
@@ -202,16 +203,18 @@ renderMinMaxBudget state =
             [ css "py-3" ]
             [ HH.text "Max Budget (Optional)" ]
         , Input.percentage_
-            [ Formless.onBlurWith _minBudget
-            , HP.value $ fromMaybe "" minBudget.input
+            [ Formless.onValueChangeWith _minBudget
+            , Formless.onBlurWith _minBudget
+            , HP.value minBudget.input
             ]
         ]
     , Range.range
         [ css "px-4 flex-4 self-end my-5"
         , HP.min 0.0
         , HP.max 100.0
-        --  , HE.onValueChange $ Formless.handleChange _minBudget
-        , HP.value $ fromMaybe "0.0" minBudget.input
+        , Formless.onValueChangeWith _minBudget
+        , Formless.onBlurWith _minBudget
+        , HP.value minBudget.input
         ]
     , HH.label
         [ css "flex-1 block text-center" ]
@@ -219,8 +222,9 @@ renderMinMaxBudget state =
             [ css "py-3" ]
             [ HH.text "Max Budget (Optional)"
             , Input.percentage_
-                [ Formless.onBlurWith _maxBudget
-                , HP.value $ fromMaybe "" maxBudget.input
+                [ Formless.onValueInputWith _maxBudget
+                , Formless.onBlurWith _maxBudget
+                , HP.value maxBudget.input
                 ]
             ]
         ]

--- a/example/real-world/Render/GroupForm.purs
+++ b/example/real-world/Render/GroupForm.purs
@@ -1,7 +1,13 @@
 module Example.RealWorld.Render.GroupForm where
 
+import Effect.Aff (Aff)
+import Example.RealWorld.Data.Group (GroupForm)
+import Example.RealWorld.Types (GroupCQ, Query, GroupCS)
+import Formless as Formless
 import Halogen.HTML as HH
 
-render :: forall t1 t2 t3. t1 -> HH.HTML t3 t2
+render
+  :: Formless.State GroupForm Aff
+  -> Formless.HTML Query GroupCQ GroupCS GroupForm Aff
 render state =
-  HH.div_ []
+  HH.div_ [ HH.text "I am the group form." ]

--- a/example/real-world/Render/GroupForm.purs
+++ b/example/real-world/Render/GroupForm.purs
@@ -1,0 +1,7 @@
+module Example.RealWorld.Render.GroupForm where
+
+import Halogen.HTML as HH
+
+render :: forall t1 t2 t3. t1 -> HH.HTML t3 t2
+render state =
+  HH.div_ []

--- a/example/real-world/Render/GroupForm.purs
+++ b/example/real-world/Render/GroupForm.purs
@@ -201,7 +201,7 @@ renderMinMaxBudget state =
         [ css "flex-1 block text-center" ]
         [ HH.div
             [ css "py-3" ]
-            [ HH.text "Max Budget (Optional)" ]
+            [ HH.text "Min Budget (Optional)" ]
         , Input.percentage_
             [ Formless.onValueChangeWith _minBudget
             , Formless.onBlurWith _minBudget

--- a/example/real-world/Render/Nav.purs
+++ b/example/real-world/Render/Nav.purs
@@ -36,8 +36,16 @@ tabs state =
   where
     group f = f
       [ HE.onClick $ HE.input_ $ Select GroupFormTab ]
-      [ HH.text "Group Form" ]
+      [ HH.text $ "Group Form" <>
+          if state.groupFormErrors > 0
+            then " (" <> show state.groupFormErrors  <> ")"
+            else ""
+      ]
 
     options f = f
       [ HE.onClick $ HE.input_ $ Select OptionsFormTab ]
-      [ HH.text "Options Form" ]
+      [ HH.text $ "Options Form" <>
+          if state.optionsFormErrors > 0
+            then " (" <> show state.optionsFormErrors  <> ")"
+            else ""
+      ]

--- a/example/real-world/Render/Nav.purs
+++ b/example/real-world/Render/Nav.purs
@@ -1,0 +1,34 @@
+module Example.RealWorld.Render.Nav where
+
+import Prelude
+
+import Effect.Aff (Aff)
+import Example.RealWorld.Types (ChildQuery, ChildSlot, Query(..), State, Tab(..))
+import Halogen as H
+import Halogen.HTML as HH
+import Halogen.HTML.Events as HE
+import Ocelot.HTML.Properties (css)
+
+tabs :: State -> H.ParentHTML Query ChildQuery ChildSlot Aff
+tabs state =
+  HH.ul
+  [ css "list-reset flex" ]
+  [ HH.li
+    [ css "mr-3" ]
+    [ HH.p
+      [ if state.focus == GroupFormTab then css selected else css notSelected
+      , HE.onClick $ HE.input_ $ Select GroupFormTab ]
+      [ HH.text "Group Form" ]
+    ]
+  , HH.li
+    [ css "mr-3" ]
+    [ HH.p
+      [ if state.focus == OptionsFormTab then css selected else css notSelected
+      , HE.onClick $ HE.input_ $ Select OptionsFormTab ]
+      [ HH.text "Options Form" ]
+    ]
+  ]
+  where
+    selected = "inline-block border rounded py-1 px-3 bg-black text-white"
+    notSelected = "inline-block border rounded text-black py-1 px-3"
+

--- a/example/real-world/Render/Nav.purs
+++ b/example/real-world/Render/Nav.purs
@@ -7,6 +7,7 @@ import Example.RealWorld.Types (ChildQuery, ChildSlot, Query(..), State, Tab(..)
 import Halogen as H
 import Halogen.HTML as HH
 import Halogen.HTML.Events as HE
+import Ocelot.Block.Button (button, buttonDark, buttonPrimary) as Button
 import Ocelot.HTML.Properties (css)
 
 tabs :: State -> H.ParentHTML Query ChildQuery ChildSlot Aff
@@ -15,20 +16,28 @@ tabs state =
   [ css "list-reset flex" ]
   [ HH.li
     [ css "mr-3" ]
-    [ HH.p
-      [ if state.focus == GroupFormTab then css selected else css notSelected
-      , HE.onClick $ HE.input_ $ Select GroupFormTab ]
-      [ HH.text "Group Form" ]
+    [ if state.focus == GroupFormTab
+        then group Button.button
+        else group Button.buttonDark
     ]
   , HH.li
     [ css "mr-3" ]
-    [ HH.p
-      [ if state.focus == OptionsFormTab then css selected else css notSelected
-      , HE.onClick $ HE.input_ $ Select OptionsFormTab ]
-      [ HH.text "Options Form" ]
+    [ if state.focus == OptionsFormTab
+        then options Button.button
+        else options Button.buttonDark
+    ]
+  , HH.li
+    [ css "mr-3" ]
+    [ Button.buttonPrimary
+      [ HE.onClick $ HE.input_ Submit ]
+      [ HH.text "Submit Form" ]
     ]
   ]
   where
-    selected = "inline-block border rounded py-1 px-3 bg-black text-white"
-    notSelected = "inline-block border rounded text-black py-1 px-3"
+    group f = f
+      [ HE.onClick $ HE.input_ $ Select GroupFormTab ]
+      [ HH.text "Group Form" ]
 
+    options f = f
+      [ HE.onClick $ HE.input_ $ Select OptionsFormTab ]
+      [ HH.text "Options Form" ]

--- a/example/real-world/Render/OptionsForm.purs
+++ b/example/real-world/Render/OptionsForm.purs
@@ -38,47 +38,47 @@ render :: FormlessState -> FormlessHTML
 render state =
   HH.div_
     [ Card.card_
-				[ Format.subHeading_
-					[ HH.text "Overview" ]
-				, renderEnabled state
-				]
+  			[ Format.subHeading_
+  				[ HH.text "Overview" ]
+  			, renderEnabled state
+  			]
     , HH.div
         [ if enable.input then css "" else css "hidden" ]
         [ renderMetrics state
         , renderOthers state
         ]
-		]
+  	]
   where
-		enable = unwrap $ Record.get _enable $ unwrap state.form
+  	enable = unwrap $ Record.get _enable $ unwrap state.form
 
 -----
 -- Form parts
 
 renderMetrics :: FormlessState -> FormlessHTML
 renderMetrics state =
-	Card.card_
-		[ Format.subHeading_
-			[ HH.text "Metrics" ]
-		, renderMetric state
-		,	renderMetricField metric.input
-		]
-	where
-		metric = unwrap $ Record.get _metric $ unwrap state.form
-		renderMetricField = case _ of
-			Just ViewCost -> renderViewCost state
-			Just ClickCost -> renderClickCost state
-			Just InstallCost -> renderInstallCost state
-			Nothing -> HH.div_ []
+  Card.card_
+  	[ Format.subHeading_
+  		[ HH.text "Metrics" ]
+  	, renderMetric state
+  	,	renderMetricField metric.input
+  	]
+  where
+  	metric = unwrap $ Record.get _metric $ unwrap state.form
+  	renderMetricField = case _ of
+  		Just ViewCost -> renderViewCost state
+  		Just ClickCost -> renderClickCost state
+  		Just InstallCost -> renderInstallCost state
+  		Nothing -> HH.div_ []
 
 renderOthers :: FormlessState -> FormlessHTML
 renderOthers state =
-	Card.card_
-		[ Format.subHeading_
-			[ HH.text "Other Settings" ]
-		,	renderSize state
-		, renderDimensions state
-		, renderSpeed state
-		]
+  Card.card_
+  	[ Format.subHeading_
+  		[ HH.text "Other Settings" ]
+  	,	renderSize state
+  	, renderDimensions state
+  	, renderSpeed state
+  	]
 
 
 -----
@@ -87,19 +87,19 @@ renderOthers state =
 renderEnabled :: FormlessState -> FormlessHTML
 renderEnabled state =
   FormField.field_
-		{ label: "Enable"
-		, helpText: Just "Do you want to enable this set of options?"
-		, error: showError enable
-		, inputId: "enable"
-		}
-		[ Toggle.toggle
-			[ HP.checked enable.input
+  	{ label: "Enable"
+  	, helpText: Just "Do you want to enable this set of options?"
+  	, error: showError enable
+  	, inputId: "enable"
+  	}
+  	[ Toggle.toggle
+  		[ HP.checked enable.input
       , Formless.onChangeWith _enable (not enable.input)
       , Formless.onBlurWith _enable
       ]
-		]
+  	]
   where
-		enable = unwrap $ Record.get _enable $ unwrap state.form
+  	enable = unwrap $ Record.get _enable $ unwrap state.form
 
 renderMetric :: FormlessState -> FormlessHTML
 renderMetric state =
@@ -184,21 +184,21 @@ renderSpeed state =
   [ HH.div_
     [ Radio.radio_
       [ HP.name "speed"
-			, HP.checked $ speed.input == Low
+  		, HP.checked $ speed.input == Low
       , Formless.onClickWith _speed Low
-			]
+  		]
       [ HH.text $ show Low ]
     , Radio.radio_
       [ HP.name "speed"
-			, HP.checked $ speed.input == Medium
+  		, HP.checked $ speed.input == Medium
       , Formless.onClickWith _speed Medium
       ]
       [ HH.text $ show Medium ]
     , Radio.radio_
       [ HP.name "speed"
-			, HP.checked $ speed.input == Fast
+  		, HP.checked $ speed.input == Fast
       , Formless.onClickWith _speed Fast
-		  ]
+  	  ]
       [ HH.text $ show Fast ]
     ]
   ]

--- a/example/real-world/Render/OptionsForm.purs
+++ b/example/real-world/Render/OptionsForm.purs
@@ -1,7 +1,13 @@
 module Example.RealWorld.Render.OptionsForm where
 
+import Effect.Aff (Aff)
+import Example.RealWorld.Data.Options (OptionsForm)
+import Example.RealWorld.Types (OptionsCQ, Query, OptionsCS)
+import Formless as Formless
 import Halogen.HTML as HH
 
-render :: forall t1 t2 t3. t1 -> HH.HTML t3 t2
+render
+  :: Formless.State OptionsForm Aff
+  -> Formless.HTML Query OptionsCQ OptionsCS OptionsForm Aff
 render state =
-  HH.div_ []
+  HH.div_ [ HH.text "I am the options form." ]

--- a/example/real-world/Render/OptionsForm.purs
+++ b/example/real-world/Render/OptionsForm.purs
@@ -1,13 +1,22 @@
 module Example.RealWorld.Render.OptionsForm where
 
+import Data.Maybe (Maybe(..))
 import Effect.Aff (Aff)
-import Example.RealWorld.Data.Options (OptionsForm)
+import Example.RealWorld.Data.Options as O
+import Example.RealWorld.Render.Field (text) as Field
 import Example.RealWorld.Types (OptionsCQ, Query, OptionsCS)
 import Formless as Formless
 import Halogen.HTML as HH
 
 render
-  :: Formless.State OptionsForm Aff
-  -> Formless.HTML Query OptionsCQ OptionsCS OptionsForm Aff
+  :: Formless.State O.OptionsForm Aff
+  -> Formless.HTML Query OptionsCQ OptionsCS O.OptionsForm Aff
 render state =
-  HH.div_ [ HH.text "I am the options form." ]
+  HH.div_
+    [ Field.text
+      { label: "A text field for costs"
+      , placeholder: Just "Fill me in"
+      , helpText: "I am actually in the options form."
+      , field: O._clickCost
+      } state
+    ]

--- a/example/real-world/Render/OptionsForm.purs
+++ b/example/real-world/Render/OptionsForm.purs
@@ -95,6 +95,7 @@ renderEnabled state =
 		[ Toggle.toggle
 			[ HP.checked enable.input
       , Formless.onChangeWith _enable (not enable.input)
+      , Formless.onBlurWith _enable
       ]
 		]
   where
@@ -184,16 +185,19 @@ renderSpeed state =
     [ Radio.radio_
       [ HP.name "speed"
 			, HP.checked $ speed.input == Low
+      , Formless.onClickWith _speed Low
 			]
       [ HH.text $ show Low ]
     , Radio.radio_
       [ HP.name "speed"
 			, HP.checked $ speed.input == Medium
+      , Formless.onClickWith _speed Medium
       ]
       [ HH.text $ show Medium ]
     , Radio.radio_
       [ HP.name "speed"
 			, HP.checked $ speed.input == Fast
+      , Formless.onClickWith _speed Fast
 		  ]
       [ HH.text $ show Fast ]
     ]

--- a/example/real-world/Render/OptionsForm.purs
+++ b/example/real-world/Render/OptionsForm.purs
@@ -1,0 +1,7 @@
+module Example.RealWorld.Render.OptionsForm where
+
+import Halogen.HTML as HH
+
+render :: forall t1 t2 t3. t1 -> HH.HTML t3 t2
+render state =
+  HH.div_ []

--- a/example/real-world/Render/OptionsForm.purs
+++ b/example/real-world/Render/OptionsForm.purs
@@ -1,22 +1,202 @@
 module Example.RealWorld.Render.OptionsForm where
 
-import Data.Maybe (Maybe(..))
-import Effect.Aff (Aff)
-import Example.RealWorld.Data.Options as O
-import Example.RealWorld.Render.Field (text) as Field
-import Example.RealWorld.Types (OptionsCQ, Query, OptionsCS)
-import Formless as Formless
-import Halogen.HTML as HH
+import Prelude
 
-render
-  :: Formless.State O.OptionsForm Aff
-  -> Formless.HTML Query OptionsCQ OptionsCS O.OptionsForm Aff
+import Data.Maybe (Maybe(..))
+import Data.Newtype (unwrap)
+import Effect.Aff (Aff)
+import Example.RealWorld.Data.Options
+  (Metric(..), Speed(..), _enable, _metric, _speed)
+import Example.RealWorld.Data.Options as OP
+import Example.RealWorld.Render.Field as Field
+import Example.RealWorld.Types (OptionsCQ, OptionsCS, Query(..))
+import Example.Validation.Utils (showError)
+import Formless as Formless
+import Halogen as H
+import Halogen.HTML as HH
+import Halogen.HTML.Events as HE
+import Halogen.HTML.Properties as HP
+import Ocelot.Block.Card as Card
+import Ocelot.Block.FormField as FormField
+import Ocelot.Block.Format as Format
+import Ocelot.Block.Radio as Radio
+import Ocelot.Block.Toggle as Toggle
+import Ocelot.Components.Dropdown as Dropdown
+import Ocelot.HTML.Properties (css)
+import Record as Record
+
+-- | A convenience synonym for the group Formless state
+type FormlessState
+  = Formless.State OP.OptionsForm Aff
+
+-- | A convenience synonym for the group Formless HTML type
+type FormlessHTML
+  = Formless.HTML Query OptionsCQ OptionsCS OP.OptionsForm Aff
+
+-- | The form, grouped by sections.
+render :: FormlessState -> FormlessHTML
 render state =
   HH.div_
-    [ Field.text
-      { label: "A text field for costs"
-      , placeholder: Just "Fill me in"
-      , helpText: "I am actually in the options form."
-      , field: O._clickCost
-      } state
+    [ Card.card_
+				[ Format.subHeading_
+					[ HH.text "Overview" ]
+				, renderEnabled state
+				]
+    , HH.div
+        [ if enable.input then css "" else css "hidden" ]
+        [ renderMetrics state
+        , renderOthers state
+        ]
+		]
+  where
+		enable = unwrap $ Record.get _enable $ unwrap state.form
+
+-----
+-- Form parts
+
+renderMetrics :: FormlessState -> FormlessHTML
+renderMetrics state =
+	Card.card_
+		[ Format.subHeading_
+			[ HH.text "Metrics" ]
+		, renderMetric state
+		,	renderMetricField metric.input
+		]
+	where
+		metric = unwrap $ Record.get _metric $ unwrap state.form
+		renderMetricField = case _ of
+			Just ViewCost -> renderViewCost state
+			Just ClickCost -> renderClickCost state
+			Just InstallCost -> renderInstallCost state
+			Nothing -> HH.div_ []
+
+renderOthers :: FormlessState -> FormlessHTML
+renderOthers state =
+	Card.card_
+		[ Format.subHeading_
+			[ HH.text "Other Settings" ]
+		,	renderSize state
+		, renderDimensions state
+		, renderSpeed state
+		]
+
+
+-----
+-- Fields
+
+renderEnabled :: FormlessState -> FormlessHTML
+renderEnabled state =
+  FormField.field_
+		{ label: "Enable"
+		, helpText: Just "Do you want to enable this set of options?"
+		, error: showError enable
+		, inputId: "enable"
+		}
+		[ Toggle.toggle
+			[ HP.checked enable.input
+      , Formless.onChangeWith _enable (not enable.input)
+      ]
+		]
+  where
+		enable = unwrap $ Record.get _enable $ unwrap state.form
+
+renderMetric :: FormlessState -> FormlessHTML
+renderMetric state =
+  HH.div_
+    [ Field.formField state
+      { label: "Metric"
+      , placeholder: Nothing
+      , helpText: "Choose a metric to optimize for."
+      , field: OP._metric
+      }
+      \metric ->
+        HH.slot
+          unit
+          Dropdown.dropdown
+          { selectedItem: Nothing
+          , items: [ ViewCost, ClickCost, InstallCost ]
+          , label: "Select a metric"
+          , toString: show
+          , disabled: false
+          }
+          ( HE.input
+            ( Formless.Raise
+              <<< H.action
+              <<< HandleMetricDropdown
+            )
+          )
     ]
+
+renderViewCost :: FormlessState -> FormlessHTML
+renderViewCost =
+  Field.input
+  { label: "View Cost"
+  , placeholder: Just "100"
+  , helpText: "Enter a dollar amount for view costs."
+  , field: OP._viewCost
+  } Field.Currency
+
+renderClickCost :: FormlessState -> FormlessHTML
+renderClickCost =
+  Field.input
+  { label: "Click Cost"
+  , placeholder: Just "1"
+  , helpText: "Enter a dollar amount for click costs."
+  , field: OP._clickCost
+  } Field.Currency
+
+renderInstallCost :: FormlessState -> FormlessHTML
+renderInstallCost =
+  Field.input
+  { label: "App Install Cost"
+  , placeholder: Just "10"
+  , helpText: "Enter a dollar amount for installation costs."
+  , field: OP._installCost
+  } Field.Currency
+
+renderSize :: FormlessState -> FormlessHTML
+renderSize =
+  Field.input
+  { label: "Size"
+  , placeholder: Just "1.123"
+  , helpText: "Enter a size for the campaign."
+  , field: OP._size
+  } Field.Text
+
+renderDimensions :: FormlessState -> FormlessHTML
+renderDimensions =
+  Field.input
+  { label: "Dimensions"
+  , placeholder: Just "5.2"
+  , helpText: "Enter a set of dimensions for the campaign."
+  , field: OP._dimensions
+  } Field.Text
+
+renderSpeed :: FormlessState -> FormlessHTML
+renderSpeed state =
+  FormField.fieldset_
+  { label: "Speed"
+  , inputId: "speedy-mcgee"
+  , helpText: Just "How fast do you want to go?"
+  , error: showError speed
+  }
+  [ HH.div_
+    [ Radio.radio_
+      [ HP.name "speed"
+			, HP.checked $ speed.input == Low
+			]
+      [ HH.text $ show Low ]
+    , Radio.radio_
+      [ HP.name "speed"
+			, HP.checked $ speed.input == Medium
+      ]
+      [ HH.text $ show Medium ]
+    , Radio.radio_
+      [ HP.name "speed"
+			, HP.checked $ speed.input == Fast
+		  ]
+      [ HH.text $ show Fast ]
+    ]
+  ]
+  where
+    speed = unwrap $ Record.get _speed $ unwrap state.form

--- a/example/real-world/Render/OptionsForm.purs
+++ b/example/real-world/Render/OptionsForm.purs
@@ -38,18 +38,18 @@ render :: FormlessState -> FormlessHTML
 render state =
   HH.div_
     [ Card.card_
-  			[ Format.subHeading_
-  				[ HH.text "Overview" ]
-  			, renderEnabled state
-  			]
+        [ Format.subHeading_
+          [ HH.text "Overview" ]
+        , renderEnabled state
+        ]
     , HH.div
         [ if enable.input then css "" else css "hidden" ]
         [ renderMetrics state
         , renderOthers state
         ]
-  	]
+    ]
   where
-  	enable = unwrap $ Record.get _enable $ unwrap state.form
+    enable = unwrap $ Record.get _enable $ unwrap state.form
 
 -----
 -- Form parts
@@ -57,28 +57,28 @@ render state =
 renderMetrics :: FormlessState -> FormlessHTML
 renderMetrics state =
   Card.card_
-  	[ Format.subHeading_
-  		[ HH.text "Metrics" ]
-  	, renderMetric state
-  	,	renderMetricField metric.input
-  	]
+    [ Format.subHeading_
+      [ HH.text "Metrics" ]
+    , renderMetric state
+    ,  renderMetricField metric.input
+    ]
   where
-  	metric = unwrap $ Record.get _metric $ unwrap state.form
-  	renderMetricField = case _ of
-  		Just ViewCost -> renderViewCost state
-  		Just ClickCost -> renderClickCost state
-  		Just InstallCost -> renderInstallCost state
-  		Nothing -> HH.div_ []
+    metric = unwrap $ Record.get _metric $ unwrap state.form
+    renderMetricField = case _ of
+      Just ViewCost -> renderViewCost state
+      Just ClickCost -> renderClickCost state
+      Just InstallCost -> renderInstallCost state
+      Nothing -> HH.div_ []
 
 renderOthers :: FormlessState -> FormlessHTML
 renderOthers state =
   Card.card_
-  	[ Format.subHeading_
-  		[ HH.text "Other Settings" ]
-  	,	renderSize state
-  	, renderDimensions state
-  	, renderSpeed state
-  	]
+    [ Format.subHeading_
+      [ HH.text "Other Settings" ]
+    ,  renderSize state
+    , renderDimensions state
+    , renderSpeed state
+    ]
 
 
 -----
@@ -87,19 +87,19 @@ renderOthers state =
 renderEnabled :: FormlessState -> FormlessHTML
 renderEnabled state =
   FormField.field_
-  	{ label: "Enable"
-  	, helpText: Just "Do you want to enable this set of options?"
-  	, error: showError enable
-  	, inputId: "enable"
-  	}
-  	[ Toggle.toggle
-  		[ HP.checked enable.input
+    { label: "Enable"
+    , helpText: Just "Do you want to enable this set of options?"
+    , error: showError enable
+    , inputId: "enable"
+    }
+    [ Toggle.toggle
+      [ HP.checked enable.input
       , Formless.onChangeWith _enable (not enable.input)
       , Formless.onBlurWith _enable
       ]
-  	]
+    ]
   where
-  	enable = unwrap $ Record.get _enable $ unwrap state.form
+    enable = unwrap $ Record.get _enable $ unwrap state.form
 
 renderMetric :: FormlessState -> FormlessHTML
 renderMetric state =
@@ -184,21 +184,21 @@ renderSpeed state =
   [ HH.div_
     [ Radio.radio_
       [ HP.name "speed"
-  		, HP.checked $ speed.input == Low
+      , HP.checked $ speed.input == Low
       , Formless.onClickWith _speed Low
-  		]
+      ]
       [ HH.text $ show Low ]
     , Radio.radio_
       [ HP.name "speed"
-  		, HP.checked $ speed.input == Medium
+      , HP.checked $ speed.input == Medium
       , Formless.onClickWith _speed Medium
       ]
       [ HH.text $ show Medium ]
     , Radio.radio_
       [ HP.name "speed"
-  		, HP.checked $ speed.input == Fast
+      , HP.checked $ speed.input == Fast
       , Formless.onClickWith _speed Fast
-  	  ]
+      ]
       [ HH.text $ show Fast ]
     ]
   ]

--- a/example/real-world/Spec/GroupForm.purs
+++ b/example/real-world/Spec/GroupForm.purs
@@ -1,0 +1,17 @@
+module Example.RealWorld.Spec.GroupForm where
+
+import Prelude
+
+import Example.RealWorld.Data.Group (GroupForm(..), GroupFormRow)
+import Formless.Spec as FSpec
+import Type.Row (RProxy(..))
+
+-- | mkFormSpecFromRow can produce a valid input form spec from your row
+-- | without you having to type anything.
+groupFormSpec :: GroupForm FSpec.FormSpec
+groupFormSpec = FSpec.mkFormSpecFromRow $ RProxy :: RProxy (GroupFormRow FSpec.Input)
+
+-- | You should provide your own validation. This example uses the PureScript
+-- | standard, `purescript-validation`.
+groupFormValidation :: GroupForm FSpec.InputField -> GroupForm FSpec.InputField
+groupFormValidation (GroupForm form) = GroupForm form

--- a/example/real-world/Spec/GroupForm.purs
+++ b/example/real-world/Spec/GroupForm.purs
@@ -2,8 +2,12 @@ module Example.RealWorld.Spec.GroupForm where
 
 import Prelude
 
+import Data.Maybe (Maybe(..))
+import Data.Newtype (unwrap)
 import Example.RealWorld.Data.Group (GroupForm(..), GroupFormRow)
+import Example.Validation.Semigroup as V
 import Formless.Spec as FSpec
+import Formless.Validation (onInputField)
 import Type.Row (RProxy(..))
 
 -- | mkFormSpecFromRow can produce a valid input form spec from your row
@@ -12,7 +16,23 @@ groupFormSpec :: GroupForm FSpec.FormSpec
 groupFormSpec =
   FSpec.mkFormSpecFromRow $ RProxy :: RProxy (GroupFormRow FSpec.Input)
 
--- | You should provide your own validation. This example uses the PureScript
--- | standard, `purescript-validation`.
-groupFormValidation :: GroupForm FSpec.InputField -> GroupForm FSpec.InputField
-groupFormValidation (GroupForm form) = GroupForm form
+groupFormValidation
+  :: GroupForm FSpec.InputField
+  -> GroupForm FSpec.InputField
+groupFormValidation (GroupForm form) = GroupForm
+  { name: V.validateNonEmpty `onInputField` form.name
+  , secretKey1: (\i ->
+      V.validateNonEmpty i
+      *> V.validateEqual (_.input $ unwrap form.secretKey2) i
+      ) `onInputField` form.secretKey1
+  , secretKey2: (\i ->
+      V.validateNonEmpty i
+      *> V.validateEqual (_.input $ unwrap form.secretKey1) i
+      ) `onInputField` form.secretKey2
+  , admin: V.validateMaybe `onInputField` form.admin
+  , applications: V.validateNonEmptyF `onInputField` form.applications
+  , pixels: V.validateNonEmptyF `onInputField` form.pixels
+  , maxBudget: const (pure $ Just 100) `onInputField` form.maxBudget
+  , minBudget: V.validateInt `onInputField` form.minBudget
+  , whiskey: V.validateMaybe `onInputField` form.whiskey
+  }

--- a/example/real-world/Spec/GroupForm.purs
+++ b/example/real-world/Spec/GroupForm.purs
@@ -9,7 +9,8 @@ import Type.Row (RProxy(..))
 -- | mkFormSpecFromRow can produce a valid input form spec from your row
 -- | without you having to type anything.
 groupFormSpec :: GroupForm FSpec.FormSpec
-groupFormSpec = FSpec.mkFormSpecFromRow $ RProxy :: RProxy (GroupFormRow FSpec.Input)
+groupFormSpec =
+  FSpec.mkFormSpecFromRow $ RProxy :: RProxy (GroupFormRow FSpec.Input)
 
 -- | You should provide your own validation. This example uses the PureScript
 -- | standard, `purescript-validation`.

--- a/example/real-world/Spec/OptionsForm.purs
+++ b/example/real-world/Spec/OptionsForm.purs
@@ -2,8 +2,13 @@ module Example.RealWorld.Spec.OptionsForm where
 
 import Prelude
 
-import Example.RealWorld.Data.Options (OptionsForm(..), OptionsRow)
+import Data.Int (toNumber) as Int
+import Data.Maybe (Maybe(..))
+import Data.Newtype (unwrap)
+import Example.RealWorld.Data.Options (Dollars(..), Metric(..), OptionsForm(..), OptionsRow)
+import Example.Validation.Semigroup as V
 import Formless.Spec as FSpec
+import Formless.Validation (onInputField)
 import Type.Row (RProxy(..))
 
 -- | mkFormSpecFromRow can produce a valid input form spec from your row
@@ -17,4 +22,30 @@ optionsFormSpec =
 optionsFormValidation
   :: OptionsForm FSpec.InputField
   -> OptionsForm FSpec.InputField
-optionsFormValidation (OptionsForm form) = OptionsForm form
+optionsFormValidation (OptionsForm form) =
+  case (_.input $ unwrap form.enable) of
+    false -> OptionsForm form
+    true -> OptionsForm
+      { enable: pure `onInputField` form.enable
+      , metric: V.validateMaybe `onInputField` form.metric
+      , viewCost: (\str ->
+          case (_.input $ unwrap form.metric) of
+            Just ViewCost -> (pure <<< Dollars) <$> (V.validateInt str)
+            _ -> pure Nothing
+          ) `onInputField` form.viewCost
+      , clickCost: (\str ->
+          case (_.input $ unwrap form.metric) of
+            Just ClickCost -> (pure <<< Dollars) <$> (V.validateInt str)
+            _ -> pure Nothing
+          ) `onInputField` form.clickCost
+      , installCost: (\str ->
+          case (_.input $ unwrap form.metric) of
+            Just InstallCost -> (pure <<< Dollars) <$> (V.validateInt str)
+            _ -> pure Nothing
+          ) `onInputField` form.installCost
+      , size: (\str -> Int.toNumber <$> V.validateInt str)
+          `onInputField` form.size
+      , dimensions: (\str -> Int.toNumber <$> V.validateInt str)
+          `onInputField` form.dimensions
+      , speed: pure `onInputField` form.speed
+      }

--- a/example/real-world/Spec/OptionsForm.purs
+++ b/example/real-world/Spec/OptionsForm.purs
@@ -1,0 +1,17 @@
+module Example.RealWorld.Spec.OptionsForm where
+
+import Prelude
+
+import Example.RealWorld.Data.Options (OptionsForm(..), OptionsRow)
+import Formless.Spec as FSpec
+import Type.Row (RProxy(..))
+
+-- | mkFormSpecFromRow can produce a valid input form spec from your row
+-- | without you having to type anything.
+optionsFormSpec :: OptionsForm FSpec.FormSpec
+optionsFormSpec = FSpec.mkFormSpecFromRow $ RProxy :: RProxy (OptionsRow FSpec.Input)
+
+-- | You should provide your own validation. This example uses the PureScript
+-- | standard, `purescript-validation`.
+optionsFormValidation :: OptionsForm FSpec.InputField -> OptionsForm FSpec.InputField
+optionsFormValidation (OptionsForm form) = OptionsForm form

--- a/example/real-world/Spec/OptionsForm.purs
+++ b/example/real-world/Spec/OptionsForm.purs
@@ -9,9 +9,12 @@ import Type.Row (RProxy(..))
 -- | mkFormSpecFromRow can produce a valid input form spec from your row
 -- | without you having to type anything.
 optionsFormSpec :: OptionsForm FSpec.FormSpec
-optionsFormSpec = FSpec.mkFormSpecFromRow $ RProxy :: RProxy (OptionsRow FSpec.Input)
+optionsFormSpec =
+  FSpec.mkFormSpecFromRow $ RProxy :: RProxy (OptionsRow FSpec.Input)
 
 -- | You should provide your own validation. This example uses the PureScript
 -- | standard, `purescript-validation`.
-optionsFormValidation :: OptionsForm FSpec.InputField -> OptionsForm FSpec.InputField
+optionsFormValidation
+  :: OptionsForm FSpec.InputField
+  -> OptionsForm FSpec.InputField
 optionsFormValidation (OptionsForm form) = OptionsForm form

--- a/example/real-world/Spec/OptionsForm.purs
+++ b/example/real-world/Spec/OptionsForm.purs
@@ -5,7 +5,8 @@ import Prelude
 import Data.Int (toNumber) as Int
 import Data.Maybe (Maybe(..))
 import Data.Newtype (unwrap)
-import Example.RealWorld.Data.Options (Dollars(..), Metric(..), OptionsForm(..), OptionsRow)
+import Example.RealWorld.Data.Options
+  (Dollars(..), Metric(..), OptionsForm(..), OptionsRow)
 import Example.Validation.Semigroup as V
 import Formless.Spec as FSpec
 import Formless.Validation (onInputField)

--- a/example/real-world/Types.purs
+++ b/example/real-world/Types.purs
@@ -6,7 +6,7 @@ import Data.Either.Nested (Either2)
 import Data.Functor.Coproduct.Nested (Coproduct2)
 import Effect.Aff (Aff)
 import Example.RealWorld.Data.Group (Admin, GroupForm)
-import Example.RealWorld.Data.Options (OptionsForm)
+import Example.RealWorld.Data.Options (Metric, OptionsForm)
 import Formless as Formless
 import Ocelot.Components.Dropdown as Dropdown
 import Ocelot.Components.Typeahead as TA
@@ -21,8 +21,9 @@ data Query a
   | HandleOptionsForm (Formless.Message Query OptionsForm) a
   | HandleGroupTypeahead GroupTASlot (TA.Message Query String) a
   | HandleAdminDropdown (Dropdown.Message Admin) a
-  | HandleOptionsTypeahead (TA.Message Query String) a
+  | HandleMetricDropdown (Dropdown.Message Metric) a
   | Select Tab a
+	| Submit a
 
 type State =
   { focus :: Tab }
@@ -49,7 +50,7 @@ type GroupCS = Either2
   Unit
 
 -- | Types for the options form
-type OptionsCQ = TA.Query Query String String Aff
+type OptionsCQ = Dropdown.Query Metric
 type OptionsCS = Unit
 
 ----------

--- a/example/real-world/Types.purs
+++ b/example/real-world/Types.purs
@@ -1,0 +1,54 @@
+module Example.RealWorld.Types where
+
+import Prelude
+
+import Data.Either.Nested (Either2)
+import Data.Functor.Coproduct.Nested (Coproduct2)
+import Effect.Aff (Aff)
+import Example.RealWorld.Data.Group (GroupForm)
+import Example.RealWorld.Data.Options (OptionsForm)
+import Formless as Formless
+import Ocelot.Components.Typeahead as TA
+
+----------
+-- Component
+
+-- | This component will only handle output from Formless to keep
+-- | things simple.
+data Query a
+  = HandleGroupForm (Formless.Message Query GroupForm) a
+  | HandleOptionsForm (Formless.Message Query OptionsForm) a
+  | HandleTypeahead TypeaheadSlot (TA.Message Query String) a
+
+type State = Unit
+
+-- | Now we can create _this_ component's child query and child slot pairing.
+type ChildQuery = Coproduct2
+  (Formless.Query Query GroupCQ GroupCS GroupForm Aff)
+  (Formless.Query Query OptionsCQ OptionsCS OptionsForm Aff)
+
+type ChildSlot = Either2
+  Unit
+  Unit
+
+----------
+-- Formless
+
+-- | Types for the group form
+type GroupCQ = TA.Query Query String String Aff
+type GroupCS = TypeaheadSlot
+
+-- | Types for the options form
+type OptionsCQ = TA.Query Query String String Aff
+type OptionsCS = TypeaheadSlot
+
+----------
+-- Slots
+
+data TypeaheadSlot
+  = EmailTypeahead
+  | WhiskeyTypeahead
+  | LanguageTypeahead
+
+derive instance eqTypeaheadSlot :: Eq TypeaheadSlot
+derive instance ordTypeaheadSlot :: Ord TypeaheadSlot

--- a/example/real-world/Types.purs
+++ b/example/real-world/Types.purs
@@ -19,8 +19,10 @@ data Query a
   = HandleGroupForm (Formless.Message Query GroupForm) a
   | HandleOptionsForm (Formless.Message Query OptionsForm) a
   | HandleTypeahead TypeaheadSlot (TA.Message Query String) a
+  | Select Tab a
 
-type State = Unit
+type State =
+  { focus :: Tab }
 
 -- | Now we can create _this_ component's child query and child slot pairing.
 type ChildQuery = Coproduct2
@@ -52,3 +54,13 @@ data TypeaheadSlot
 
 derive instance eqTypeaheadSlot :: Eq TypeaheadSlot
 derive instance ordTypeaheadSlot :: Ord TypeaheadSlot
+
+
+----------
+-- Navigation
+
+data Tab
+  = GroupFormTab
+  | OptionsFormTab
+derive instance eqTab :: Eq Tab
+derive instance ordTab :: Ord Tab

--- a/example/real-world/Types.purs
+++ b/example/real-world/Types.purs
@@ -5,9 +5,10 @@ import Prelude
 import Data.Either.Nested (Either2)
 import Data.Functor.Coproduct.Nested (Coproduct2)
 import Effect.Aff (Aff)
-import Example.RealWorld.Data.Group (GroupForm)
+import Example.RealWorld.Data.Group (Admin, GroupForm)
 import Example.RealWorld.Data.Options (OptionsForm)
 import Formless as Formless
+import Ocelot.Components.Dropdown as Dropdown
 import Ocelot.Components.Typeahead as TA
 
 ----------
@@ -18,7 +19,9 @@ import Ocelot.Components.Typeahead as TA
 data Query a
   = HandleGroupForm (Formless.Message Query GroupForm) a
   | HandleOptionsForm (Formless.Message Query OptionsForm) a
-  | HandleTypeahead TypeaheadSlot (TA.Message Query String) a
+  | HandleGroupTypeahead GroupTASlot (TA.Message Query String) a
+  | HandleAdminDropdown (Dropdown.Message Admin) a
+  | HandleOptionsTypeahead (TA.Message Query String) a
   | Select Tab a
 
 type State =
@@ -37,24 +40,27 @@ type ChildSlot = Either2
 -- Formless
 
 -- | Types for the group form
-type GroupCQ = TA.Query Query String String Aff
-type GroupCS = TypeaheadSlot
+type GroupCQ = Coproduct2
+  (TA.Query Query String String Aff)
+  (Dropdown.Query Admin)
+
+type GroupCS = Either2
+  GroupTASlot
+  Unit
 
 -- | Types for the options form
 type OptionsCQ = TA.Query Query String String Aff
-type OptionsCS = TypeaheadSlot
+type OptionsCS = Unit
 
 ----------
 -- Slots
 
-data TypeaheadSlot
-  = EmailTypeahead
+data GroupTASlot
+  = ApplicationsTypeahead
+  | PixelsTypeahead
   | WhiskeyTypeahead
-  | LanguageTypeahead
-
-derive instance eqTypeaheadSlot :: Eq TypeaheadSlot
-derive instance ordTypeaheadSlot :: Ord TypeaheadSlot
-
+derive instance eqGroupTASlot :: Eq GroupTASlot
+derive instance ordGroupTASlot :: Ord GroupTASlot
 
 ----------
 -- Navigation

--- a/example/real-world/Types.purs
+++ b/example/real-world/Types.purs
@@ -26,7 +26,10 @@ data Query a
 	| Submit a
 
 type State =
-  { focus :: Tab }
+  { focus :: Tab
+  , groupFormErrors :: Int
+  , optionsFormErrors :: Int
+  }
 
 -- | Now we can create _this_ component's child query and child slot pairing.
 type ChildQuery = Coproduct2

--- a/example/real-world/Types.purs
+++ b/example/real-world/Types.purs
@@ -4,8 +4,9 @@ import Prelude
 
 import Data.Either.Nested (Either2)
 import Data.Functor.Coproduct.Nested (Coproduct2)
+import Data.Maybe (Maybe)
 import Effect.Aff (Aff)
-import Example.RealWorld.Data.Group (Admin, GroupForm)
+import Example.RealWorld.Data.Group (Admin, Group, GroupForm)
 import Example.RealWorld.Data.Options (Metric, OptionsForm)
 import Formless as Formless
 import Ocelot.Components.Dropdown as Dropdown
@@ -25,10 +26,14 @@ data Query a
   | Select Tab a
   | Submit a
 
+-- | We'll keep track of both form errors so we can show them in tabs
+-- | and our ultimate goal is to result in a Group we can send to the
+-- | server.
 type State =
   { focus :: Tab
   , groupFormErrors :: Int
   , optionsFormErrors :: Int
+  , group :: Maybe Group
   }
 
 -- | Now we can create _this_ component's child query and child slot pairing.

--- a/example/real-world/Types.purs
+++ b/example/real-world/Types.purs
@@ -23,7 +23,7 @@ data Query a
   | HandleAdminDropdown (Dropdown.Message Admin) a
   | HandleMetricDropdown (Dropdown.Message Metric) a
   | Select Tab a
-	| Submit a
+  | Submit a
 
 type State =
   { focus :: Tab

--- a/readme.md
+++ b/readme.md
@@ -14,11 +14,34 @@ Install with Bower:
 bower i --save purescript-halogen-formless
 ```
 
-In general, Formless only requires that you provide a form data type, a render function, and a validation function. The component will handle all the wiring for updating fields on change or blur, running validation, managing dirty states, and the other tedious work of building a large form. On failed submission, see errors; on successful submission, see just the output values you care about. 
+In general, Formless only requires that you provide a form data type, a render function, and a validation function. The component will handle all the wiring for updating fields on change or blur, running validation, managing dirty states, and the other tedious work of building a large form. On failed submission, see errors; on successful submission, see just the output values you care about.
 
 Your render function and validation function can use any of the information that Formless preserves about the state of your form at any given moment. You are only expected to provide an initial value and validator, but Formless will generate a lot more information about the state of each field that you can use in rendering / validation.
 
 Since Formless is a renderless component, you can freely extend it with new behaviors with the Raise/Emit pattern. You can freely render and send queries to external components and they'll still work with Formless.
+
+### Validation
+
+Formless does not provide any validation for you. Instead, you can write your own validation based on `purescript-validation`'s `V` type, `purescript-polyform`'s monadic `Validation` type, stick with a traditional approach with `Either`, or whatever failure type you want. The only restriction Formless places on you is that your type can be transformed into what it uses to maintain errors under the hood:
+
+```purescript
+-- Maybe represents whether the field was validated in the first place
+-- Either represents failure or success
+{ result :: Maybe (Either error output) }
+
+-- Your validation function must have this type, in which you can freely perform monadic or applicative-style validation:
+validate :: MyForm InputField -> m (MyForm InputField)
+```
+
+If you use common libraries like `purescript-validation` or `purescript-polyform`, there are helper functions that will perform this transformation for you.
+
+For example, the `onInputField` function takes a function `i -> V e o` and converts it to work properly on Formless's underlying types.
+
+```purescript
+{ myField: (\i -> validateNonEmpty i *> validateMinimumLength i 7) `onInputField` myField }
+```
+
+See the examples for more.
 
 ## Examples
 

--- a/src/Class/Initial.purs
+++ b/src/Class/Initial.purs
@@ -1,0 +1,60 @@
+module Formless.Class.Initial where
+
+import Prelude
+
+import Data.List (List)
+import Data.Map (Map)
+import Data.Maybe (Maybe)
+import Data.Monoid (class MonoidRecord)
+import Data.Tuple (Tuple(..))
+import Prim.RowList (class RowToList) as RL
+
+-- | A type class that provides initial values for form fields. While superficially similar to
+-- | Haskell's `Default` type class, this class is only meant for the purposes of defining
+-- | initial form values. If you need a default value for a field in your form, you are better
+-- | off defining it as a `Maybe` field and providing a default as part of validation.
+-- |
+-- | In general, if you find yourself reaching for this type class without defining your form
+-- | as a row and generating your form spec from it, then you are probably not doing what you intend.
+class Initial v where
+  initial :: v
+
+instance initialUnit :: Initial Unit where
+  initial = mempty
+
+instance initialBoolean :: Initial Boolean where
+  initial = false
+
+instance initialInt :: Initial Int where
+  initial = 0
+
+instance initialNumber :: Initial Number where
+  initial = 0.0
+
+instance initialString :: Initial String where
+  initial = mempty
+
+instance initialOrdering :: Initial Ordering where
+  initial = mempty
+
+instance initialMaybe :: Semigroup a => Initial (Maybe a) where
+  initial = mempty
+
+instance initialArray :: Initial (Array a) where
+  initial = mempty
+
+instance initialList :: Initial (List a) where
+  initial = mempty
+
+instance initialMap :: Ord k => Initial (Map k v) where
+  initial = mempty
+
+instance initialFn :: Monoid b => Initial (a -> b) where
+  initial = mempty
+
+instance initialTuple :: (Initial a, Initial b) => Initial (Tuple a b) where
+  initial = Tuple initial initial
+
+instance initialRecord :: (RL.RowToList row list, MonoidRecord list row row) => Initial (Record row) where
+  initial = mempty
+

--- a/src/Class/Initial.purs
+++ b/src/Class/Initial.purs
@@ -4,7 +4,7 @@ import Prelude
 
 import Data.List (List)
 import Data.Map (Map)
-import Data.Maybe (Maybe)
+import Data.Maybe (Maybe(..))
 import Data.Monoid (class MonoidRecord)
 import Data.Tuple (Tuple(..))
 import Prim.RowList (class RowToList) as RL
@@ -37,8 +37,8 @@ instance initialString :: Initial String where
 instance initialOrdering :: Initial Ordering where
   initial = mempty
 
-instance initialMaybe :: Semigroup a => Initial (Maybe a) where
-  initial = mempty
+instance initialMaybe :: Initial (Maybe a) where
+  initial = Nothing
 
 instance initialArray :: Initial (Array a) where
   initial = mempty

--- a/src/Formless.purs
+++ b/src/Formless.purs
@@ -92,7 +92,7 @@ component
   => RL.RowToList field fieldxs
   => RL.RowToList mboutput mboutputxs
   => FR.FormSpecToInputField specxs spec () field
-  => FR.ValidateInputFields fieldxs field () field
+  --  => FR.ValidateInputFields fieldxs field () field
   => FR.InputFieldToMaybeOutput fieldxs field () mboutput
   => FR.MaybeOutputToOutputField mboutputxs mboutput () output
   => Newtype (form FormSpec) (Record spec)
@@ -130,7 +130,7 @@ component =
 
     ValidateAll a -> do
       st <- getState
-      let form = FR.validateInputFields st.form
+      let form = st.form -- FR.validateInputFields st.form
       modifyState_ _
         { form = form
         , formResult = FR.maybeOutputToOutputField $ FR.inputFieldToMaybeOutput form
@@ -189,16 +189,16 @@ handleBlur'
   => SProxy sym
   -> form'
   -> form'
-handleBlur' sym form = wrap <<< setResult <<< setTouched $ unwrap form
+handleBlur' sym form = wrap <<< setTouched $ unwrap form
   where
     _sym :: Lens.Lens' (Record form) (InputField inp err out)
     _sym = prop sym
     input =
       Lens.view (_sym <<< _Newtype <<< prop FSpec._input) (unwrap form)
-    validator =
-      Lens.view (_sym <<< _Newtype <<< prop FSpec._validator) (unwrap form)
-    setResult =
-      Lens.set (_sym <<< _Newtype <<< prop FSpec._result) (Just $ validator input)
+    --  validator =
+    --    Lens.view (_sym <<< _Newtype <<< prop FSpec._validator) (unwrap form)
+    --  setResult =
+    --    Lens.set (_sym <<< _Newtype <<< prop FSpec._result) (Just $ validator input)
     setTouched =
       Lens.set (_sym <<< _Newtype <<< prop FSpec._touched) true
 

--- a/src/Formless.purs
+++ b/src/Formless.purs
@@ -27,6 +27,7 @@ import Prim.RowList (class RowToList) as RL
 import Renderless.State (getState, modifyState_, modifyStore_)
 import Web.Event.Event (Event)
 import Web.UIEvent.FocusEvent (FocusEvent)
+import Web.UIEvent.MouseEvent (MouseEvent)
 
 data Query pq cq cs (form :: (Type -> Type -> Type -> Type) -> Type) m a
   = HandleBlur (form InputField -> form InputField) a
@@ -242,6 +243,16 @@ onValueInputWith
 onValueInputWith sym =
   HE.onValueInput \str -> Just (handleChange sym str)
 
+onValueChangeWith
+  :: ∀ pq cq cs m sym form' form err out r props
+   . IsSymbol sym
+  => Cons sym (InputField String err out) r form
+  => Newtype (form' InputField) (Record form)
+  => SProxy sym
+  -> HP.IProp (onChange :: Event, value :: String | props) (Query pq cq cs form' m Unit)
+onValueChangeWith sym =
+  HE.onValueChange \str -> Just (handleChange sym str)
+
 onChangeWith
   :: ∀ pq cq cs m sym form' form i err out r props
    . IsSymbol sym
@@ -252,6 +263,17 @@ onChangeWith
   -> HP.IProp (onChange :: Event | props) (Query pq cq cs form' m Unit)
 onChangeWith sym i =
   HE.onChange \_ -> Just (handleChange sym i)
+
+onClickWith
+  :: ∀ pq cq cs m sym form' form i err out r props
+   . IsSymbol sym
+  => Cons sym (InputField i err out) r form
+  => Newtype (form' InputField) (Record form)
+  => SProxy sym
+  -> i
+  -> HP.IProp (onClick :: MouseEvent | props) (Query pq cq cs form' m Unit)
+onClickWith sym i =
+  HE.onClick \_ -> Just (handleChange sym i)
 
 handleChange
   :: ∀ pq cq cs m sym form' form inp err out r

--- a/src/Formless.purs
+++ b/src/Formless.purs
@@ -15,7 +15,7 @@ import Data.Lens.Record (prop)
 import Data.Maybe (Maybe(..), maybe)
 import Data.Newtype (class Newtype, unwrap, wrap)
 import Data.Symbol (class IsSymbol, SProxy)
-import Formless.Record as FR
+import Formless.Internal as Internal
 import Formless.Spec (FormSpec, InputField, MaybeOutput, OutputField)
 import Formless.Spec as FSpec
 import Halogen as H
@@ -94,10 +94,10 @@ component
   => RL.RowToList spec specxs
   => RL.RowToList field fieldxs
   => RL.RowToList mboutput mboutputxs
-  => FR.FormSpecToInputField specxs spec () field
-  => FR.SetInputFieldsTouched fieldxs field () field
-  => FR.InputFieldToMaybeOutput fieldxs field () mboutput
-  => FR.MaybeOutputToOutputField mboutputxs mboutput () output
+  => Internal.FormSpecToInputField specxs spec () field
+  => Internal.SetInputFieldsTouched fieldxs field () field
+  => Internal.InputFieldToMaybeOutput fieldxs field () mboutput
+  => Internal.MaybeOutputToOutputField mboutputxs mboutput () output
   => Newtype (form FormSpec) (Record spec)
   => Newtype (form InputField) (Record field)
   => Newtype (form MaybeOutput) (Record mboutput)
@@ -119,7 +119,7 @@ component =
     , formResult: Nothing
     , formSpec
     , validator
-    , form: FR.formSpecToInputFields formSpec
+    , form: Internal.formSpecToInputFields formSpec
     }
 
   eval :: Query pq cq cs form m ~> DSL pq cq cs form m
@@ -137,13 +137,13 @@ component =
       form <- H.lift $ st.validator st.form
       modifyState_ _
         { form = form
-        , formResult = FR.maybeOutputToOutputField $ FR.inputFieldToMaybeOutput form
+        , formResult = Internal.maybeOutputToOutputField $ Internal.inputFieldToMaybeOutput form
         }
       pure a
 
     Submit a -> do
       -- Set all fields to 'touched' so validation is forced
-      modifyState_ \st -> st { form = FR.setInputFieldsTouched st.form }
+      modifyState_ \st -> st { form = Internal.setInputFieldsTouched st.form }
       _ <- eval $ Validate a
       st <- getState
       H.raise $ maybe (Submitted $ Left st.form) (Submitted <<< Right) st.formResult

--- a/src/Internal/Internal.purs
+++ b/src/Internal/Internal.purs
@@ -78,7 +78,7 @@ maybeOutputToOutputField r = map wrap $ Builder.build <@> {} <$> builder
 -----
 -- Classes (Internal)
 
--- |
+-- | A class to set all input fields to touched for validation purposes
 class SetInputFieldsTouched
   (xs :: RL.RowList) (row :: # Type) (from :: # Type) (to :: # Type)
   | xs -> from to where

--- a/src/Internal/Internal.purs
+++ b/src/Internal/Internal.purs
@@ -1,4 +1,4 @@
-module Formless.Record where
+module Formless.Internal where
 
 import Prelude
 

--- a/src/Record/Record.purs
+++ b/src/Record/Record.purs
@@ -17,18 +17,18 @@ import Type.Data.RowList (RLProxy(..))
 -----
 -- Functions
 
--- | A helper function that will run and apply all validation functions to current
--- | inputs to produce the same record, this time with results.
---  validateInputFields
---    :: ∀ row xs form
---     . RL.RowToList row xs
---    => ValidateInputFields xs row () row
---    => Newtype (form InputField) (Record row)
---    => form InputField
---    -> form InputField
---  validateInputFields r = wrap $ Builder.build builder {}
---    where
---      builder = validateInputFieldsBuilder (RLProxy :: RLProxy xs) (unwrap r)
+-- | A helper function that will set all input fields to 'touched = true'. This ensures
+-- | subsequent validations apply to all fields even if not edited by the user.
+setInputFieldsTouched
+  :: ∀ row xs form
+   . RL.RowToList row xs
+  => SetInputFieldsTouched xs row () row
+  => Newtype (form InputField) (Record row)
+  => form InputField
+  -> form InputField
+setInputFieldsTouched r = wrap $ Builder.build builder {}
+  where
+    builder = setInputFieldsTouchedBuilder (RLProxy :: RLProxy xs) (unwrap r)
 
 -- | A helper function that will automatically transform a record of FormSpec(s) into
 -- | a record of InputField(s).
@@ -78,36 +78,31 @@ maybeOutputToOutputField r = map wrap $ Builder.build <@> {} <$> builder
 -----
 -- Classes (Internal)
 
--- | The class that provides the Builder implementation to efficiently apply validation
--- | to inputs and produce results
---  class ValidateInputFields
---    (xs :: RL.RowList) (row :: # Type) (from :: # Type) (to :: # Type)
---    | xs -> from to where
---    validateInputFieldsBuilder :: RLProxy xs -> Record row -> Builder { | from } { | to }
---
---  instance validateInputFieldsNil :: ValidateInputFields RL.Nil row () () where
---    validateInputFieldsBuilder _ _ = identity
---
---  instance validateInputFieldsCons
---    :: ( IsSymbol name
---       , Row.Cons name (InputField i e o) trash row
---       , ValidateInputFields tail row from from'
---       , Row.Lacks name from'
---       , Row.Cons name (InputField i e o) from' to
---       )
---    => ValidateInputFields (RL.Cons name (InputField i e o) tail) row from to where
---    validateInputFieldsBuilder _ r =
---      first <<< rest
---      where
---        _name = SProxy :: SProxy name
---        val = transform $ Record.get _name r
---        rest = validateInputFieldsBuilder (RLProxy :: RLProxy tail) r
---        first = Builder.insert _name val
---        transform (InputField { input, touched }) = InputField
---          { input
---          , touched
---          , result: Just $ validator input
---          }
+-- |
+class SetInputFieldsTouched
+  (xs :: RL.RowList) (row :: # Type) (from :: # Type) (to :: # Type)
+  | xs -> from to where
+  setInputFieldsTouchedBuilder :: RLProxy xs -> Record row -> Builder { | from } { | to }
+
+instance setInputFieldsTouchedNil :: SetInputFieldsTouched RL.Nil row () () where
+  setInputFieldsTouchedBuilder _ _ = identity
+
+instance setInputFieldsTouchedCons
+  :: ( IsSymbol name
+     , Row.Cons name (InputField i e o) trash row
+     , SetInputFieldsTouched tail row from from'
+     , Row.Lacks name from'
+     , Row.Cons name (InputField i e o) from' to
+     )
+  => SetInputFieldsTouched (RL.Cons name (InputField i e o) tail) row from to where
+  setInputFieldsTouchedBuilder _ r =
+    first <<< rest
+    where
+      _name = SProxy :: SProxy name
+      val = transform $ Record.get _name r
+      rest = setInputFieldsTouchedBuilder (RLProxy :: RLProxy tail) r
+      first = Builder.insert _name val
+      transform (InputField i) = InputField i { touched = true }
 
 -- | The class that provides the Builder implementation to efficiently transform the record
 -- | of FormSpec to record of InputField.

--- a/src/Record/Record.purs
+++ b/src/Record/Record.purs
@@ -19,16 +19,16 @@ import Type.Data.RowList (RLProxy(..))
 
 -- | A helper function that will run and apply all validation functions to current
 -- | inputs to produce the same record, this time with results.
-validateInputFields
-  :: ∀ row xs form
-   . RL.RowToList row xs
-  => ValidateInputFields xs row () row
-  => Newtype (form InputField) (Record row)
-  => form InputField
-  -> form InputField
-validateInputFields r = wrap $ Builder.build builder {}
-  where
-    builder = validateInputFieldsBuilder (RLProxy :: RLProxy xs) (unwrap r)
+--  validateInputFields
+--    :: ∀ row xs form
+--     . RL.RowToList row xs
+--    => ValidateInputFields xs row () row
+--    => Newtype (form InputField) (Record row)
+--    => form InputField
+--    -> form InputField
+--  validateInputFields r = wrap $ Builder.build builder {}
+--    where
+--      builder = validateInputFieldsBuilder (RLProxy :: RLProxy xs) (unwrap r)
 
 -- | A helper function that will automatically transform a record of FormSpec(s) into
 -- | a record of InputField(s).
@@ -80,35 +80,34 @@ maybeOutputToOutputField r = map wrap $ Builder.build <@> {} <$> builder
 
 -- | The class that provides the Builder implementation to efficiently apply validation
 -- | to inputs and produce results
-class ValidateInputFields
-  (xs :: RL.RowList) (row :: # Type) (from :: # Type) (to :: # Type)
-  | xs -> from to where
-  validateInputFieldsBuilder :: RLProxy xs -> Record row -> Builder { | from } { | to }
-
-instance validateInputFieldsNil :: ValidateInputFields RL.Nil row () () where
-  validateInputFieldsBuilder _ _ = identity
-
-instance validateInputFieldsCons
-  :: ( IsSymbol name
-     , Row.Cons name (InputField i e o) trash row
-     , ValidateInputFields tail row from from'
-     , Row.Lacks name from'
-     , Row.Cons name (InputField i e o) from' to
-     )
-  => ValidateInputFields (RL.Cons name (InputField i e o) tail) row from to where
-  validateInputFieldsBuilder _ r =
-    first <<< rest
-    where
-      _name = SProxy :: SProxy name
-      val = transform $ Record.get _name r
-      rest = validateInputFieldsBuilder (RLProxy :: RLProxy tail) r
-      first = Builder.insert _name val
-      transform (InputField { input, touched, validator }) = InputField
-        { input
-        , touched
-        , validator
-        , result: Just $ validator input
-        }
+--  class ValidateInputFields
+--    (xs :: RL.RowList) (row :: # Type) (from :: # Type) (to :: # Type)
+--    | xs -> from to where
+--    validateInputFieldsBuilder :: RLProxy xs -> Record row -> Builder { | from } { | to }
+--
+--  instance validateInputFieldsNil :: ValidateInputFields RL.Nil row () () where
+--    validateInputFieldsBuilder _ _ = identity
+--
+--  instance validateInputFieldsCons
+--    :: ( IsSymbol name
+--       , Row.Cons name (InputField i e o) trash row
+--       , ValidateInputFields tail row from from'
+--       , Row.Lacks name from'
+--       , Row.Cons name (InputField i e o) from' to
+--       )
+--    => ValidateInputFields (RL.Cons name (InputField i e o) tail) row from to where
+--    validateInputFieldsBuilder _ r =
+--      first <<< rest
+--      where
+--        _name = SProxy :: SProxy name
+--        val = transform $ Record.get _name r
+--        rest = validateInputFieldsBuilder (RLProxy :: RLProxy tail) r
+--        first = Builder.insert _name val
+--        transform (InputField { input, touched }) = InputField
+--          { input
+--          , touched
+--          , result: Just $ validator input
+--          }
 
 -- | The class that provides the Builder implementation to efficiently transform the record
 -- | of FormSpec to record of InputField.
@@ -135,10 +134,9 @@ instance formSpecToInputFieldCons
       val = transform $ Record.get _name r
       rest = formSpecToInputFieldBuilder (RLProxy :: RLProxy tail) r
       first = Builder.insert _name val
-      transform (FormSpec { input, validator }) = InputField
+      transform (FormSpec input) = InputField
         { input
         , touched: false
-        , validator
         , result: Nothing
         }
 

--- a/src/Spec/Spec.purs
+++ b/src/Spec/Spec.purs
@@ -9,10 +9,7 @@ import Data.Symbol (SProxy(..))
 -- | create the spec form that we'll compare against to measure
 -- | 'touched' states, etc. This is what the user is responsible
 -- | for providing.
-newtype FormSpec input error output = FormSpec
-  { input :: input
-  , validator :: input -> Either error output
-  }
+newtype FormSpec input error output = FormSpec input
 derive instance newtypeFormSpec :: Newtype (FormSpec i e o) _
 
 -- | The type that we need to record state across the form, but
@@ -21,8 +18,7 @@ derive instance newtypeFormSpec :: Newtype (FormSpec i e o) _
 newtype InputField input error output = InputField
   { input :: input
   , touched :: Boolean
-  , validator :: input -> Either error output
-  , result :: Maybe (Either error output)
+  , result :: Maybe (Either error output) -- force the user to end up in Either?
   }
 derive instance newtypeInputField :: Newtype (InputField i e o) _
 

--- a/src/Spec/Spec.purs
+++ b/src/Spec/Spec.purs
@@ -1,9 +1,18 @@
 module Formless.Spec where
 
+import Prelude
+
 import Data.Either (Either)
 import Data.Maybe (Maybe)
-import Data.Newtype (class Newtype)
-import Data.Symbol (SProxy(..))
+import Data.Newtype (class Newtype, wrap)
+import Data.Symbol (class IsSymbol, SProxy(..))
+import Formless.Class.Initial (class Initial, initial)
+import Prim.Row as Row
+import Prim.RowList as RL
+import Record as Record
+import Record.Builder (Builder)
+import Record.Builder as Builder
+import Type.Row (RLProxy(..), RProxy)
 
 -- | The type that will be applied to the user's input row to
 -- | create the spec form that we'll compare against to measure
@@ -38,3 +47,127 @@ derive instance newtypeOutputField :: Newtype (OutputField i e o) _
 newtype MaybeOutput i e o = MaybeOutput (Maybe o)
 derive instance newtypeMaybeOutput :: Newtype (MaybeOutput i e o) _
 
+
+----------
+-- Helper types
+
+-- | A type synonym that lets you pick out just the input type from
+-- | your form row.
+type Input input error output = input
+
+-- | A type synonym that lets you pick out just the error type from
+-- | your form row.
+type Error input error output = error
+
+-- | A type synonym that lets you pick out just the output type from
+-- | your form row.
+type Output input error output = output
+
+
+----------
+-- Class
+
+-- | A function to transform a record of initial values into a FormSpec. Exists to save
+-- | you from too many redundant key strokes.
+-- |
+-- | ```purescript
+-- | newtype Form f = Form
+-- |   { name :: f String String String }
+-- | derive instance newtypeForm :: Newtype (Form f) _
+-- |
+-- | formSpec :: Form FormSpec
+-- | formSpec = mkFormSpec { name: "" }
+-- | ```
+mkFormSpec
+  :: ∀ row xs row' form
+   . RL.RowToList row xs
+  => MakeFormSpec xs row () row'
+  => Newtype (form FormSpec) (Record row')
+  => Record row
+  -> form FormSpec
+mkFormSpec r = wrap $ Builder.build builder {}
+  where
+    builder = mkFormSpecBuilder (RLProxy :: RLProxy xs) r
+
+-- | The class that provides the Builder implementation to efficiently transform a normal
+-- | into a proper FormSpec by wrapping it in newtypes
+class MakeFormSpec
+  (xs :: RL.RowList) (row :: # Type) (from :: # Type) (to :: # Type)
+  | xs -> from to where
+  mkFormSpecBuilder :: RLProxy xs -> Record row -> Builder { | from } { | to }
+
+instance mkFormSpecNil :: MakeFormSpec RL.Nil row () () where
+  mkFormSpecBuilder _ _ = identity
+
+instance mkFormSpecCons
+  :: ( IsSymbol name
+     , Row.Cons name i trash row
+     , MakeFormSpec tail row from from'
+     , Row.Lacks name from'
+     , Row.Cons name (FormSpec i e o) from' to
+     )
+  => MakeFormSpec (RL.Cons name i tail) row from to where
+  mkFormSpecBuilder _ r =
+    first <<< rest
+    where
+      _name = SProxy :: SProxy name
+      val = FormSpec $ Record.get _name r
+      rest = mkFormSpecBuilder (RLProxy :: RLProxy tail) r
+      first = Builder.insert _name val
+
+-- | A function to transform a row of labels into a FormSpec. This allows you to go directly
+-- | from a custom form newtype to a spec without having to fill in any values at all. Requires
+-- | that all members have an instance of the `Initial` type class (all monoidal values do by
+-- | default, along with some other primitives).
+-- |
+-- | ```purescript
+-- | newtype Form f = Form (Record (MyRow f))
+-- | derive instance newtypeForm :: Newtype (Form f) _
+-- |
+-- | type MyRow f =
+-- |   ( name :: f String String String
+-- |   , email :: f String Void String
+-- |   , age :: f String String Int
+-- |   )
+-- |
+-- | -- To retrieve input types only, use the Input type synonym
+-- | formSpec :: Form FormSpec
+-- | formSpec = mkFormSpecFromRow (RProxy :: RProxy (MyRow Input))
+
+mkFormSpecFromRow
+  :: ∀ row xs row' form
+   . RL.RowToList row xs
+  => MakeFormSpecFromRow xs row () row'
+  => Newtype (form FormSpec) (Record row')
+  => RProxy row
+  -> form FormSpec
+mkFormSpecFromRow r = wrap $ Builder.build builder {}
+  where
+    builder = mkFormSpecFromRowBuilder (RLProxy :: RLProxy xs) r
+
+-- | The class that provides the Builder implementation to efficiently transform a normal
+-- | into a proper FormSpec by wrapping it in newtypes
+class MakeFormSpecFromRow
+  (xs :: RL.RowList) (row :: # Type) (from :: # Type) (to :: # Type)
+  | xs -> from to where
+  mkFormSpecFromRowBuilder :: RLProxy xs -> RProxy row -> Builder { | from } { | to }
+
+instance mkFormSpecFromRowNil :: MakeFormSpecFromRow RL.Nil row () () where
+  mkFormSpecFromRowBuilder _ _ = identity
+
+instance mkFormSpecFromRowCons
+  :: ( IsSymbol name
+     , Initial i
+     , Row.Cons name i trash row
+     , MakeFormSpecFromRow tail row from from'
+     , Row.Lacks name from'
+     , Row.Cons name (FormSpec i e o) from' to
+     )
+  => MakeFormSpecFromRow (RL.Cons name i tail) row from to where
+  mkFormSpecFromRowBuilder _ r =
+    first <<< rest
+    where
+      _name = SProxy :: SProxy name
+      val = FormSpec initial
+      rest = mkFormSpecFromRowBuilder (RLProxy :: RLProxy tail) r
+      first = Builder.insert _name val

--- a/src/Spec/Spec.purs
+++ b/src/Spec/Spec.purs
@@ -185,7 +185,7 @@ instance mkFormSpecCons
 -- | -- To retrieve input types only, use the Input type synonym
 -- | formSpec :: Form FormSpec
 -- | formSpec = mkFormSpecFromRow (RProxy :: RProxy (MyRow Input))
-
+-- | ```
 mkFormSpecFromRow
   :: ∀ row xs row' form
    . RL.RowToList row xs

--- a/src/Validation/Validation.purs
+++ b/src/Validation/Validation.purs
@@ -1,0 +1,23 @@
+module Formless.Validation where
+
+import Prelude
+
+import Data.Either (Either(..))
+import Data.Maybe (Maybe(..))
+import Data.Validation.Semigroup (V, unV)
+import Formless.Spec (InputField(..))
+
+-- | Turn a `V` validator into one that operates on InputField
+-- | directly, not validating untouched fields.
+onInputField
+  :: ∀ i e o
+   . (i -> V e o)
+  -> InputField i e o
+  -> InputField i e o
+onInputField validator field@(InputField i)
+  | not i.touched = field
+  | otherwise = InputField $ unV
+      (\e -> i { result = Just $ Left e })
+      (\v -> i { result = Just $ Right v })
+      (validator i.input)
+

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -2,80 +2,12 @@ module Test.Main where
 
 import Prelude
 
-import Data.Either (Either(..))
-import Data.List.NonEmpty (NonEmptyList)
-import Data.Maybe (Maybe(..))
-import Data.Newtype (class Newtype)
-import Debug.Trace (spy)
 import Effect (Effect)
-import Example.Validation.Semigroup (InvalidPrimitive, validateMinimumLength)
-import Formless.Spec (FormSpec(..), InputField(..))
-import Formless.Validation (onInputField)
 import Test.Unit (suite, test)
-import Test.Unit.Assert as Assert
 import Test.Unit.Main (runTest)
 
 main :: Effect Unit
 main = runTest do
   suite "pure form validation" do
     test "validates" do
-      let _ = spy "input form" inForm
-          _ = spy "intended output form" $ outForm
-          _ = spy "output form" $ validateForm outForm
-      Assert.equal 0 0
-
------
--- Types
-
-newtype Form f = Form
-  { name :: f String (NonEmptyList InvalidPrimitive) String
-  , text :: f String Void String
-  }
-derive instance newtypeForm :: Newtype (Form f) _
-
-formSpec :: Form FormSpec
-formSpec = Form
-  { name: FormSpec ""
-  , text: FormSpec ""
-  }
-
-validateForm
-  :: Form InputField
-  -> Form InputField
-validateForm (Form form) = Form
-  { name: (flip validateMinimumLength 10) `onInputField` form.name
-  , text: pure `onInputField` form.text
-  }
-
------
--- Example Forms
-
-inForm :: Form InputField
-inForm = Form
-  { name: InputField
-    { input: "Jordan"
-    , touched: true
-    , result: Nothing
-    }
-  , text: InputField
-    { input: ""
-    , touched: false
-    , result: Nothing
-    }
-  }
-
-outForm :: Form InputField
-outForm = Form
-  { name: InputField
-    { input: "Jordan"
-    , touched: true
-    , result: Just $ Right "Jordan"
-    }
-  , text: InputField
-    { input: ""
-    , touched: false
-    , result: Nothing
-    }
-  }
-
-
+      pure unit

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -1,9 +1,81 @@
 module Test.Main where
 
 import Prelude
+
+import Data.Either (Either(..))
+import Data.List.NonEmpty (NonEmptyList)
+import Data.Maybe (Maybe(..))
+import Data.Newtype (class Newtype)
+import Debug.Trace (spy)
 import Effect (Effect)
-import Effect.Console (log)
+import Example.Validation.Semigroup (InvalidPrimitive, validateMinimumLength)
+import Formless.Spec (FormSpec(..), InputField(..))
+import Formless.Validation (onInputField)
+import Test.Unit (suite, test)
+import Test.Unit.Assert as Assert
+import Test.Unit.Main (runTest)
 
 main :: Effect Unit
-main = do
-  log "You should add some tests."
+main = runTest do
+  suite "pure form validation" do
+    test "validates" do
+      let _ = spy "input form" inForm
+          _ = spy "intended output form" $ outForm
+          _ = spy "output form" $ validateForm outForm
+      Assert.equal 0 0
+
+-----
+-- Types
+
+newtype Form f = Form
+  { name :: f String (NonEmptyList InvalidPrimitive) String
+  , text :: f String Void String
+  }
+derive instance newtypeForm :: Newtype (Form f) _
+
+formSpec :: Form FormSpec
+formSpec = Form
+  { name: FormSpec ""
+  , text: FormSpec ""
+  }
+
+validateForm
+  :: Form InputField
+  -> Form InputField
+validateForm (Form form) = Form
+  { name: (flip validateMinimumLength 10) `onInputField` form.name
+  , text: pure `onInputField` form.text
+  }
+
+-----
+-- Example Forms
+
+inForm :: Form InputField
+inForm = Form
+  { name: InputField
+    { input: "Jordan"
+    , touched: true
+    , result: Nothing
+    }
+  , text: InputField
+    { input: ""
+    , touched: false
+    , result: Nothing
+    }
+  }
+
+outForm :: Form InputField
+outForm = Form
+  { name: InputField
+    { input: "Jordan"
+    , touched: true
+    , result: Just $ Right "Jordan"
+    }
+  , text: InputField
+    { input: ""
+    , touched: false
+    , result: Nothing
+    }
+  }
+
+


### PR DESCRIPTION
## What does this pull request do?

This PR removes validation as a concern of the `Formless` library, instead deferring to validation entirely provided by the user, which can make use of all the information within `InputField`. This provides more flexibility to users while reducing boilerplate in the library.

To aid with this validation, I've added the `onInputField` helper function to transform `purescript-validation` functions into ones that can operate on input field types. See the `Formless.Validation` module for more. I'll add more helpers to this over time.

In addition, there are several new helpers:
- `unwrapOutput` turns a `form OutputField` into a simple record of field names with their output values after a form is successfully submitted.
- `mkFormSpec` turns a simple record of field names and input values into a `FormSpec`
- `mkFormSpecFromRow` allows users to only pass in a row type and get an entire form spec generated on their behalf (and, in turn, all the rest of the types required by the library)
- the `Initial` type class is what allows `mkFormSpecFromRow` to work. It allows you to provide initial starting values for forms. It is not intended to be a class for defaults.

There are also some new types:
- `Input` picks out the input type from input, error, output
- `Error` picks out the error type from input, error, output
- `Output` picks out the output type from input, error, output

Some types have changed:
- `InputField` no longer carries a validator function
- `FormSpec` no longer carries a validator function, nor is it a record at all. I may be able to erase this type altogether in the future (I can just call `mkFormSpec` on the user's behalf) if I don't appear to need any more fields from it.

Some functions have been changed:
- `handleBlur` and `handleChange` no longer perform any validation, and only update `touched` values. The equivalent queries trigger the `Validate` query, and that one does use the user's validation function.
- `Submit` now sets all fields to 'touched', then runs validation, then raises the result.

## Other Notes:

The README has been updated, as well as the examples and docs. However, there are no complex validation examples or monadic validation examples to draw from. This will be necessary before any official release.
