### PR TITLE
Improved submission, state updates, and resets

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "purescript-prelude": "^4.0.1",
     "purescript-halogen": "^4.0.0",
-    "purescript-halogen-renderless": "^0.0.2"
+    "purescript-halogen-renderless": "^0.0.3"
   },
   "devDependencies": {
     "purescript-ocelot": "git@github.com:citizennet/purescript-ocelot.git#master",

--- a/example/basic/Component.purs
+++ b/example/basic/Component.purs
@@ -66,9 +66,10 @@ validator (Form form) = pure $ Form
 
 -- | When the form is run, it will produce your Form type, with
 -- | only the output fields. Since our Contact type is the same
--- | shape as the Form type, we can just unwrap the newtypes.
-parser :: Form OutputField -> Contact
-parser = unwrapOutput
+-- | shape as the Form type, we can just unwrap the newtypes. This can
+-- | be monadic, like hitting a server for extra information.
+submitter :: ∀ m. Monad m => Form OutputField -> m Contact
+submitter = pure <<< unwrapOutput
 
 
 -----
@@ -106,7 +107,7 @@ component = H.parentComponent
         Formless.component
         { formSpec
         , validator
-        , parser
+        , submitter
         , render: formless
         }
         (const Nothing)

--- a/example/external-components/Component.purs
+++ b/example/external-components/Component.purs
@@ -7,7 +7,7 @@ import Data.Symbol (SProxy(..))
 import Effect.Aff (Aff)
 import Effect.Console (log) as Console
 import Example.ExternalComponents.RenderForm (formless)
-import Example.ExternalComponents.Spec (User, _email, _language, _whiskey, formSpec, formValidation, outputParser)
+import Example.ExternalComponents.Spec (User, _email, _language, _whiskey, formSpec, submitter, validator)
 import Example.ExternalComponents.Types (ChildQuery, ChildSlot, Query(..), Slot(..), State)
 import Formless as Formless
 import Halogen as H
@@ -54,10 +54,8 @@ component =
         unit
         Formless.component
         { formSpec
-          -- We wrote a pure validator, but could have written an effectful one. For that reason
-          -- we'll need to map pure over the result.
-        , validator: pure <$> formValidation
-        , parser: outputParser
+        , validator
+        , submitter
         , render: formless
         }
         (HE.input HandleFormless)

--- a/example/external-components/Component.purs
+++ b/example/external-components/Component.purs
@@ -3,10 +3,11 @@ module Example.ExternalComponents.Component where
 import Prelude
 
 import Data.Maybe (Maybe(..))
+import Data.Symbol (SProxy(..))
 import Effect.Aff (Aff)
 import Effect.Console (log) as Console
 import Example.ExternalComponents.RenderForm (formless)
-import Example.ExternalComponents.Spec (_email, _language, _whiskey, formSpec, formValidation, outputParser)
+import Example.ExternalComponents.Spec (User, _email, _language, _whiskey, formSpec, formValidation, outputParser)
 import Example.ExternalComponents.Types (ChildQuery, ChildSlot, Query(..), Slot(..), State)
 import Formless as Formless
 import Halogen as H
@@ -15,6 +16,7 @@ import Halogen.HTML.Events as HE
 import Ocelot.Block.Format as Format
 import Ocelot.Components.Typeahead as TA
 import Ocelot.HTML.Properties (css)
+import Record (delete)
 
 component :: H.Component HH.HTML Query Unit Void Aff
 component =
@@ -69,9 +71,14 @@ component =
       -- calling `eval`
       Formless.Emit q -> eval q *> pure a
 
-      -- Formless will provide your result on successful submission.
+      -- Formless will provide your result type on successful submission.
       Formless.Submitted user -> do
-        H.liftEffect $ Console.log $ show user
+        H.liftEffect $ Console.log $ show (user :: User)
+        pure a
+
+      -- Formless will alert you with the new summary state if it is changed.
+      Formless.Changed fstate -> do
+        H.liftEffect $ Console.log $ show $ delete (SProxy :: SProxy "form") fstate
         pure a
 
     HandleTypeahead slot m a -> case m of

--- a/example/external-components/RenderForm.purs
+++ b/example/external-components/RenderForm.purs
@@ -15,9 +15,11 @@ import Halogen.HTML.Events as HE
 import Halogen.HTML.Properties as HP
 import Ocelot.Block.Button as Button
 import Ocelot.Block.FormField as FormField
-import Ocelot.Block.Input (input) as Input
+import Ocelot.Block.Format as Format
+import Ocelot.Block.Input as Input
 import Ocelot.Components.Typeahead as TA
 import Ocelot.Components.Typeahead.Input as TA.Input
+import Ocelot.HTML.Properties (css)
 import Record as Record
 
 -- | Our render function has access to anything in Formless' State type, plus
@@ -31,9 +33,26 @@ formless state =
     , renderEmail state
     , renderWhiskey state
     , renderLanguage state
+    , Format.p_
+      [ HH.text $
+          "You can only attempt to submit this form if it is valid "
+          <> "and not already being submitted. You can only attempt "
+          <> "to reset the form if it has been changed from its initial "
+          <> "state."
+      ]
     , Button.buttonPrimary
-      [ HE.onClick $ HE.input_ Formless.Submit ]
+      [ if state.submitting || state.validity /= Formless.Valid
+          then HP.disabled true
+          else HE.onClick $ HE.input_ Formless.Submit
+      , css "mr3"
+      ]
       [ HH.text "Submit" ]
+    , Button.button
+      [ if not state.dirty
+          then HP.disabled true
+          else HE.onClick $ HE.input_ Formless.Reset
+      ]
+      [ HH.text "Reset" ]
     ]
 
 ----------

--- a/example/external-components/RenderForm.purs
+++ b/example/external-components/RenderForm.purs
@@ -44,13 +44,13 @@ formless state =
       [ if state.submitting || state.validity /= Formless.Valid
           then HP.disabled true
           else HE.onClick $ HE.input_ Formless.Submit
-      , css "mr3"
+      , css "mr-3"
       ]
       [ HH.text "Submit" ]
     , Button.button
       [ if not state.dirty
           then HP.disabled true
-          else HE.onClick $ HE.input_ Formless.Reset
+          else HE.onClick $ HE.input_ $ Formless.Raise (Reset unit)
       ]
       [ HH.text "Reset" ]
     ]

--- a/example/external-components/RenderForm.purs
+++ b/example/external-components/RenderForm.purs
@@ -5,7 +5,7 @@ import Prelude
 import Data.Maybe (Maybe(..))
 import Data.Newtype (unwrap)
 import Effect.Aff (Aff)
-import Example.ExternalComponents.Spec (Form, _email, _name, _language, _whiskey)
+import Example.ExternalComponents.Spec (Form, User, _email, _language, _name, _whiskey)
 import Example.ExternalComponents.Types (FCQ, FCS, Query(..), Slot(..))
 import Example.Validation.Utils (showError)
 import Formless as Formless
@@ -23,8 +23,8 @@ import Record as Record
 -- | Our render function has access to anything in Formless' State type, plus
 -- | anything additional in your own state type.
 formless
-  :: Formless.State Form Aff
-  -> Formless.HTML Query FCQ FCS Form Aff
+  :: Formless.State Form User Aff
+  -> Formless.HTML Query FCQ FCS Form User Aff
 formless state =
   HH.div_
     [ renderName state
@@ -40,7 +40,7 @@ formless state =
 -- Helpers
 
 -- | A helper function to render a form text input
-renderName :: Formless.State Form Aff -> Formless.HTML Query FCQ FCS Form Aff
+renderName :: Formless.State Form User Aff -> Formless.HTML Query FCQ FCS Form User Aff
 renderName state =
   HH.div_
     [ FormField.field_
@@ -60,7 +60,7 @@ renderName state =
   where
     field = unwrap $ Record.get _name $ unwrap state.form
 
-renderEmail :: Formless.State Form Aff -> Formless.HTML Query FCQ FCS Form Aff
+renderEmail :: Formless.State Form User Aff -> Formless.HTML Query FCQ FCS Form User Aff
 renderEmail state =
   HH.div_
     [ FormField.field_
@@ -88,7 +88,7 @@ renderEmail state =
   where
     field = unwrap $ Record.get _email $ unwrap state.form
 
-renderWhiskey :: Formless.State Form Aff -> Formless.HTML Query FCQ FCS Form Aff
+renderWhiskey :: Formless.State Form User Aff -> Formless.HTML Query FCQ FCS Form User Aff
 renderWhiskey state =
   HH.div_
     [ FormField.field_
@@ -115,7 +115,7 @@ renderWhiskey state =
   where
     field = unwrap $ Record.get _whiskey $ unwrap state.form
 
-renderLanguage :: Formless.State Form Aff -> Formless.HTML Query FCQ FCS Form Aff
+renderLanguage :: Formless.State Form User Aff -> Formless.HTML Query FCQ FCS Form User Aff
 renderLanguage state =
   HH.div_
     [ FormField.field_

--- a/example/external-components/Spec.purs
+++ b/example/external-components/Spec.purs
@@ -45,16 +45,17 @@ formSpec = FSpec.mkFormSpecFromRow $ RProxy :: RProxy (FormRow FSpec.Input)
 
 -- | You should provide your own validation. This example uses the PureScript
 -- | standard, `purescript-validation`.
-formValidation :: Form FSpec.InputField -> Form FSpec.InputField
-formValidation (Form form) = Form
-  { name: (\i -> V.validateNonEmpty i *> V.validateMinimumLength i 7) `onInputField` form.name
-  , email: (\i -> V.validateMaybe i *> V.validateEmailRegex (fromMaybe "" i)) `onInputField` form.email
-  , whiskey: V.validateMaybe `onInputField` form.whiskey
-  , language: V.validateMaybe `onInputField` form.language
-  }
+validator :: ∀ m. Monad m => Form FSpec.InputField -> m (Form FSpec.InputField)
+validator (Form form) = pure $
+  Form
+    { name: (\i -> V.validateNonEmpty i *> V.validateMinimumLength i 7) `onInputField` form.name
+    , email: (\i -> V.validateMaybe i *> V.validateEmailRegex (fromMaybe "" i)) `onInputField` form.email
+    , whiskey: V.validateMaybe `onInputField` form.whiskey
+    , language: V.validateMaybe `onInputField` form.language
+    }
 
 -- | You should provide a function from the form with only output values to your ideal
 -- | parsed type. Since your output type is identical to the form's shape, you can simply
 -- | unwrap the form with a helper from Formless.
-outputParser :: Form OutputField -> User
-outputParser = unwrapOutput
+submitter :: ∀ m. Monad m => Form OutputField -> m User
+submitter = pure <<< unwrapOutput

--- a/example/external-components/Spec.purs
+++ b/example/external-components/Spec.purs
@@ -6,6 +6,7 @@ import Data.Maybe (Maybe, fromMaybe)
 import Data.Newtype (class Newtype)
 import Data.Symbol (SProxy(..))
 import Example.Validation.Semigroup as V
+import Formless.Spec (Output, OutputField, unwrapOutput)
 import Formless.Spec as FSpec
 import Formless.Validation (onInputField)
 import Type.Row (RProxy(..))
@@ -14,6 +15,11 @@ import Type.Row (RProxy(..))
 -- | rather than a record accepting `f`, we're just providing a row.
 newtype Form f = Form (Record (FormRow f))
 derive instance newtypeForm :: Newtype (Form f) _
+
+-- | This is the actual type you want to parse to and use throughout your program.
+-- | In this case, it'll be the exact record output by the form, but in many cases,
+-- | it may be another shape.
+type User = Record (FormRow Output)
 
 -- | We'll use this row to generate our form spec, but also to represent the
 -- | available fields in the record.
@@ -47,3 +53,8 @@ formValidation (Form form) = Form
   , language: V.validateMaybe `onInputField` form.language
   }
 
+-- | You should provide a function from the form with only output values to your ideal
+-- | parsed type. Since your output type is identical to the form's shape, you can simply
+-- | unwrap the form with a helper from Formless.
+outputParser :: Form OutputField -> User
+outputParser = unwrapOutput

--- a/example/external-components/Types.purs
+++ b/example/external-components/Types.purs
@@ -3,7 +3,7 @@ module Example.ExternalComponents.Types where
 import Prelude
 
 import Effect.Aff (Aff)
-import Example.ExternalComponents.Spec (Form)
+import Example.ExternalComponents.Spec (Form, User)
 import Formless as Formless
 import Ocelot.Components.Typeahead as TA
 
@@ -13,13 +13,13 @@ import Ocelot.Components.Typeahead as TA
 -- | This component will only handle output from Formless to keep
 -- | things simple.
 data Query a
-  = HandleFormless (Formless.Message Query Form) a
+  = HandleFormless (Formless.Message Query User) a
   | HandleTypeahead Slot (TA.Message Query String) a
 
 type State = Unit
 
 -- | Now we can create _this_ component's child query and child slot pairing.
-type ChildQuery = Formless.Query Query FCQ FCS Form Aff
+type ChildQuery = Formless.Query Query FCQ FCS Form User Aff
 type ChildSlot = Unit
 
 

--- a/example/external-components/Types.purs
+++ b/example/external-components/Types.purs
@@ -13,7 +13,7 @@ import Ocelot.Components.Typeahead as TA
 -- | This component will only handle output from Formless to keep
 -- | things simple.
 data Query a
-  = HandleFormless (Formless.Message Query User) a
+  = HandleFormless (Formless.Message Query Form User) a
   | HandleTypeahead Slot (TA.Message Query String) a
 
 type State = Unit

--- a/example/external-components/Types.purs
+++ b/example/external-components/Types.purs
@@ -10,11 +10,14 @@ import Ocelot.Components.Typeahead as TA
 ----------
 -- Component
 
--- | This component will only handle output from Formless to keep
--- | things simple.
+-- | This component manages several typeahead components, plus
+-- | Formless. Because of the external components, it needs its
+-- | own reset query to clear those components when Formless
+-- | has been reset by the user.
 data Query a
   = HandleFormless (Formless.Message Query Form User) a
   | HandleTypeahead Slot (TA.Message Query String) a
+  | Reset a
 
 type State = Unit
 

--- a/example/real-world/Component.purs
+++ b/example/real-world/Component.purs
@@ -11,8 +11,8 @@ import Example.RealWorld.Data.Options (Options(..), _metric)
 import Example.RealWorld.Render.GroupForm as GroupForm
 import Example.RealWorld.Render.Nav as Nav
 import Example.RealWorld.Render.OptionsForm as OptionsForm
-import Example.RealWorld.Spec.GroupForm (groupFormParser, groupFormSpec, groupFormValidation)
-import Example.RealWorld.Spec.OptionsForm (optionsFormSpec, optionsFormValidation)
+import Example.RealWorld.Spec.GroupForm (groupFormSpec, groupFormSubmit, groupFormValidate)
+import Example.RealWorld.Spec.OptionsForm (optionsFormSpec, optionsFormValidate)
 import Example.RealWorld.Types (ChildQuery, ChildSlot, GroupTASlot(..), Query(..), State, Tab(..))
 import Formless as Formless
 import Formless.Spec (unwrapOutput)
@@ -75,8 +75,8 @@ component =
           unit
           Formless.component
           { formSpec: groupFormSpec
-          , validator: pure <$> groupFormValidation
-          , parser: groupFormParser
+          , validator: groupFormValidate
+          , submitter: groupFormSubmit
           , render: GroupForm.render
           }
           (HE.input HandleGroupForm)
@@ -88,8 +88,8 @@ component =
           unit
           Formless.component
           { formSpec: optionsFormSpec
-          , validator: pure <$> optionsFormValidation
-          , parser: Options <<< unwrapOutput
+          , validator: pure <$> optionsFormValidate
+          , submitter: pure <<< Options <<< unwrapOutput
           , render: OptionsForm.render
           }
           (HE.input HandleOptionsForm)

--- a/example/real-world/Data/Group.purs
+++ b/example/real-world/Data/Group.purs
@@ -92,6 +92,8 @@ newtype Group = Group
     )
   )
 derive instance newtypeGroup :: Newtype Group _
+derive newtype instance eqGroup :: Eq Group
+derive newtype instance showGroup :: Show Group
 
 _id = SProxy :: SProxy "id"
 _secretKey = SProxy :: SProxy "secretKey"

--- a/example/real-world/Data/Options.purs
+++ b/example/real-world/Data/Options.purs
@@ -22,6 +22,8 @@ import Formless.Spec as FSpec
 -- | This data type represents dollar amounts
 newtype Dollars = Dollars Int
 derive instance newtypeDollars :: Newtype Dollars _
+derive newtype instance eqDollars :: Eq Dollars
+derive newtype instance showDollars :: Show Dollars
 
 -- | This data type represents different metrics a user
 -- | can choose from. Depending on what metric they choose,
@@ -92,6 +94,8 @@ _speed = SProxy :: SProxy "speed"
 -- | as the form and the underlying row.
 newtype Options = Options (Record (OptionsRow FSpec.Output))
 derive instance newtypeOptions :: Newtype Options _
+derive newtype instance eqOptions :: Eq Options
+derive newtype instance showOptions :: Show Options
 
 -- | Here's the Form type we'll use to run with Formless. The fields are the same as the
 -- | underlying row.

--- a/example/real-world/Render/Field.purs
+++ b/example/real-world/Render/Field.purs
@@ -36,15 +36,15 @@ data FieldType
   | Text
 
 input
-  :: ∀ form sym e o t0 fields m pq cq cs
+  :: ∀ form sym e o t0 fields m pq cq cs out
    . IsSymbol sym
   => Show e
   => Newtype (form InputField) (Record fields)
   => Cons sym (InputField String e o) t0 fields
   => FieldConfig sym
   -> FieldType
-  -> Formless.State form m
-  -> Formless.HTML pq cq cs form m
+  -> Formless.State form out m
+  -> Formless.HTML pq cq cs form out m
 input config ft state =
   HH.div_
     [ formField state config $ \field ->
@@ -65,20 +65,20 @@ input config ft state =
 -- | A utility to help create form fields using an unwrapped
 -- | field value from a given symbol.
 formField
-  :: ∀ form sym i e o t0 fields m pq cq cs
+  :: ∀ form sym i e o t0 fields m pq cq cs out
    . IsSymbol sym
   => Show e
   => Newtype (form InputField) (Record fields)
   => Cons sym (InputField i e o) t0 fields
-  => Formless.State form m
+  => Formless.State form out m
   -> FieldConfig sym
   -> ( { result :: Maybe (Either e o)
        , touched :: Boolean
        , input :: i
        }
-       -> Formless.HTML pq cq cs form m
+       -> Formless.HTML pq cq cs form out m
      )
-  -> Formless.HTML pq cq cs form m
+  -> Formless.HTML pq cq cs form out m
 formField state config html =
   HH.div_
     [ FormField.field_

--- a/example/real-world/Render/GroupForm.purs
+++ b/example/real-world/Render/GroupForm.purs
@@ -33,11 +33,11 @@ import Record (get) as Record
 
 -- | A convenience synonym for the group Formless state
 type FormlessState
-  = Formless.State G.GroupForm Aff
+  = Formless.State G.GroupForm G.Group Aff
 
 -- | A convenience synonym for the group Formless HTML type
 type FormlessHTML
-  = Formless.HTML Query GroupCQ GroupCS G.GroupForm Aff
+  = Formless.HTML Query GroupCQ GroupCS G.GroupForm G.Group Aff
 
 -- | The form, grouped by sections.
 render :: FormlessState -> FormlessHTML

--- a/example/real-world/Render/OptionsForm.purs
+++ b/example/real-world/Render/OptionsForm.purs
@@ -27,11 +27,11 @@ import Record as Record
 
 -- | A convenience synonym for the group Formless state
 type FormlessState
-  = Formless.State OP.OptionsForm Aff
+  = Formless.State OP.OptionsForm OP.Options Aff
 
 -- | A convenience synonym for the group Formless HTML type
 type FormlessHTML
-  = Formless.HTML Query OptionsCQ OptionsCS OP.OptionsForm Aff
+  = Formless.HTML Query OptionsCQ OptionsCS OP.OptionsForm OP.Options Aff
 
 -- | The form, grouped by sections.
 render :: FormlessState -> FormlessHTML

--- a/example/real-world/Spec/GroupForm.purs
+++ b/example/real-world/Spec/GroupForm.purs
@@ -21,34 +21,45 @@ groupFormSpec =
 
 -- | We can use simple record manipulations to change the group form result
 -- | into our output type
-groupFormParser :: GroupForm OutputField -> Group
-groupFormParser = Group
-  <<< Record.delete (SProxy :: SProxy "secretKey2")
-  <<< Record.rename (SProxy :: SProxy "secretKey1") (SProxy :: SProxy "secretKey")
-  <<< Record.insert (SProxy :: SProxy "id") (GroupId 10)
-  <<< Record.insert (SProxy :: SProxy "options") Nothing
-  <<< unwrapOutput
+groupFormSubmit :: ∀ m. Monad m => GroupForm OutputField -> m Group
+groupFormSubmit form = do
+  -- This could be a server call or something else that is necessary
+  -- to collect the information to complete your output type.
+  groupId <- pure (GroupId 10)
+  pure $ Group
+    <<< Record.delete (SProxy :: SProxy "secretKey2")
+    <<< Record.rename (SProxy :: SProxy "secretKey1") (SProxy :: SProxy "secretKey")
+    <<< Record.insert (SProxy :: SProxy "id") groupId
+    <<< Record.insert (SProxy :: SProxy "options") Nothing
+    $ unwrapOutput form
 
 -- | We'll provide a fairly involved validation function to verify the fields are
 -- | correct. This includes things like dependent validation.
-groupFormValidation
-  :: GroupForm FSpec.InputField
-  -> GroupForm FSpec.InputField
-groupFormValidation (GroupForm form) = GroupForm
-  { name: V.validateNonEmpty `onInputField` form.name
-  , secretKey1: (\i ->
-      V.validateNonEmpty i
-      *> V.validateEqual (_.input $ unwrap form.secretKey2) i
-      ) `onInputField` form.secretKey1
-  , secretKey2: (\i ->
-      V.validateNonEmpty i
-      *> V.validateEqual (_.input $ unwrap form.secretKey1) i
-      ) `onInputField` form.secretKey2
-  , admin: V.validateMaybe `onInputField` form.admin
-  , applications: V.validateNonEmptyF `onInputField` form.applications
-  , pixels: V.validateNonEmptyF `onInputField` form.pixels
-  , maxBudget: const (pure $ Just 100) `onInputField` form.maxBudget
-  , minBudget: V.validateInt `onInputField` form.minBudget
-  , whiskey: V.validateMaybe `onInputField` form.whiskey
-  }
+groupFormValidate
+  :: ∀ m
+   . Monad m
+  => GroupForm FSpec.InputField
+  -> m (GroupForm FSpec.InputField)
+groupFormValidate (GroupForm form) = pure $
+  GroupForm
+    { name: V.validateNonEmpty `onInputField` form.name
+    , secretKey1:
+        (\i ->
+          V.validateNonEmpty i
+          *> V.validateEqual (_.input $ unwrap form.secretKey2) i
+        )
+        `onInputField` form.secretKey1
+    , secretKey2:
+        (\i ->
+          V.validateNonEmpty i
+          *> V.validateEqual (_.input $ unwrap form.secretKey1) i
+        )
+        `onInputField` form.secretKey2
+    , admin: V.validateMaybe `onInputField` form.admin
+    , applications: V.validateNonEmptyF `onInputField` form.applications
+    , pixels: V.validateNonEmptyF `onInputField` form.pixels
+    , maxBudget: const (pure $ Just 100) `onInputField` form.maxBudget
+    , minBudget: V.validateInt `onInputField` form.minBudget
+    , whiskey: V.validateMaybe `onInputField` form.whiskey
+    }
 

--- a/example/real-world/Spec/OptionsForm.purs
+++ b/example/real-world/Spec/OptionsForm.purs
@@ -20,10 +20,10 @@ optionsFormSpec =
 
 -- | You should provide your own validation. This example uses the PureScript
 -- | standard, `purescript-validation`.
-optionsFormValidation
+optionsFormValidate
   :: OptionsForm FSpec.InputField
   -> OptionsForm FSpec.InputField
-optionsFormValidation (OptionsForm form) =
+optionsFormValidate (OptionsForm form) =
   case (_.input $ unwrap form.enable) of
     false -> OptionsForm form
     true -> OptionsForm

--- a/example/real-world/Types.purs
+++ b/example/real-world/Types.purs
@@ -18,8 +18,8 @@ import Ocelot.Components.Typeahead as TA
 -- | This component will only handle output from Formless to keep
 -- | things simple.
 data Query a
-  = HandleGroupForm (Formless.Message Query Group) a
-  | HandleOptionsForm (Formless.Message Query Options) a
+  = HandleGroupForm (Formless.Message Query GroupForm Group) a
+  | HandleOptionsForm (Formless.Message Query OptionsForm Options) a
   | HandleGroupTypeahead GroupTASlot (TA.Message Query String) a
   | HandleAdminDropdown (Dropdown.Message Admin) a
   | HandleMetricDropdown (Dropdown.Message Metric) a

--- a/example/real-world/Types.purs
+++ b/example/real-world/Types.purs
@@ -7,7 +7,7 @@ import Data.Functor.Coproduct.Nested (Coproduct2)
 import Data.Maybe (Maybe)
 import Effect.Aff (Aff)
 import Example.RealWorld.Data.Group (Admin, Group, GroupForm)
-import Example.RealWorld.Data.Options (Metric, OptionsForm)
+import Example.RealWorld.Data.Options (Metric, Options, OptionsForm)
 import Formless as Formless
 import Ocelot.Components.Dropdown as Dropdown
 import Ocelot.Components.Typeahead as TA
@@ -18,8 +18,8 @@ import Ocelot.Components.Typeahead as TA
 -- | This component will only handle output from Formless to keep
 -- | things simple.
 data Query a
-  = HandleGroupForm (Formless.Message Query GroupForm) a
-  | HandleOptionsForm (Formless.Message Query OptionsForm) a
+  = HandleGroupForm (Formless.Message Query Group) a
+  | HandleOptionsForm (Formless.Message Query Options) a
   | HandleGroupTypeahead GroupTASlot (TA.Message Query String) a
   | HandleAdminDropdown (Dropdown.Message Admin) a
   | HandleMetricDropdown (Dropdown.Message Metric) a
@@ -41,8 +41,8 @@ type State =
 
 -- | Now we can create _this_ component's child query and child slot pairing.
 type ChildQuery = Coproduct2
-  (Formless.Query Query GroupCQ GroupCS GroupForm Aff)
-  (Formless.Query Query OptionsCQ OptionsCS OptionsForm Aff)
+  (Formless.Query Query GroupCQ GroupCS GroupForm Group Aff)
+  (Formless.Query Query OptionsCQ OptionsCS OptionsForm Options Aff)
 
 type ChildSlot = Either2
   Unit

--- a/src/Formless.purs
+++ b/src/Formless.purs
@@ -128,26 +128,23 @@ data Message pq out
 
 -- | The component itself
 component
-  :: ∀ pq cq cs form out m spec specxs field fieldxs mboutput mboutputxs output countxs count inputs inputsxs
+  :: ∀ pq cq cs form out m spec specxs field fieldxs output countxs count inputs inputsxs
    . Ord cs
   => Monad m
   => RL.RowToList spec specxs
   => RL.RowToList field fieldxs
-  => RL.RowToList mboutput mboutputxs
   => RL.RowToList count countxs
   => RL.RowToList inputs inputsxs
   => EqRecord inputsxs inputs
   => Internal.FormSpecToInputField specxs spec () field
   => Internal.InputFieldsToInput fieldxs field () inputs
   => Internal.SetInputFieldsTouched fieldxs field () field
-  => Internal.InputFieldToMaybeOutput fieldxs field () mboutput
-  => Internal.MaybeOutputToOutputField mboutputxs mboutput () output
+  => Internal.InputFieldToMaybeOutput fieldxs field () output
   => Internal.CountErrors fieldxs field () count
   => Internal.SumRecord countxs count (Additive Int)
   => Newtype (form FormSpec) (Record spec)
   => Newtype (form InputField) (Record field)
   => Newtype (form OutputField) (Record output)
-  => Newtype (form Internal.MaybeOutput) (Record mboutput)
   => Newtype (form Internal.Input) (Record inputs)
   => Component pq cq cs form out m
 component =
@@ -297,10 +294,7 @@ component =
     pure $
       if st.validity == Valid
         then let internal = unwrap st.internal
-                 outputs =
-                   Internal.maybeOutputToOutputField
-                   $ Internal.inputFieldToMaybeOutput
-                   $ st.form
+                 outputs = Internal.inputFieldToMaybeOutput st.form
               in internal.parser <$> outputs
         else Nothing
 

--- a/src/Internal/Internal.purs
+++ b/src/Internal/Internal.purs
@@ -2,7 +2,7 @@ module Formless.Internal where
 
 import Prelude
 
-import Data.Either (Either(..))
+import Data.Either (Either(..), hush)
 import Data.Maybe (Maybe(..))
 import Data.Monoid.Additive (Additive(..))
 import Data.Newtype (class Newtype, unwrap, wrap)
@@ -17,11 +17,6 @@ import Type.Data.RowList (RLProxy(..))
 
 -----
 -- Types
-
--- | Never exposed to the user, but used to
--- | aid transformations
-newtype MaybeOutput i e o = MaybeOutput (Maybe o)
-derive instance newtypeMaybeOutput :: Newtype (MaybeOutput i e o) _
 
 -- | Never exposed to the user, but used to aid equality instances for
 -- | checking dirty states.
@@ -103,29 +98,12 @@ inputFieldToMaybeOutput
    . RL.RowToList row xs
   => InputFieldToMaybeOutput xs row () row'
   => Newtype (form InputField) (Record row)
-  => Newtype (form MaybeOutput) (Record row')
+  => Newtype (form OutputField) (Record row')
   => form InputField
-  -> form MaybeOutput
-inputFieldToMaybeOutput r = wrap $ Builder.build builder {}
+  -> Maybe (form OutputField)
+inputFieldToMaybeOutput r = map wrap $ Builder.build <@> {} <$> builder
   where
     builder = inputFieldToMaybeOutputBuilder (RLProxy :: RLProxy xs) (unwrap r)
-
--- | A function that, when used with `inputFieldToMaybeOutput`, turns a record of
--- | InputField into a record of OutputField if all fields in the record are successfully
--- | validated.
-maybeOutputToOutputField
-  :: ∀ i e o row xs row' form
-   . RL.RowToList row xs
-  => MaybeOutputToOutputField xs row () row'
-  => Newtype (MaybeOutput i e o) (Maybe o)
-  => Newtype (form MaybeOutput) (Record row)
-  => Newtype (form OutputField) (Record row')
-  => form MaybeOutput
-  -> Maybe (form OutputField)
-maybeOutputToOutputField r = map wrap $ Builder.build <@> {} <$> builder
-  where
-    builder = maybeOutputToOutputFieldBuilder (RLProxy :: RLProxy xs) (unwrap r)
-
 
 -----
 -- Classes (Internal)
@@ -215,66 +193,34 @@ instance formSpecToInputFieldCons
         }
 
 -- | The class that provides the Builder implementation to efficiently transform the record
--- | of InputField to record of MaybeOutput.
+-- | of MaybeOutput to a record of OutputField, but only if all fields were successfully
+-- | validated.
 class InputFieldToMaybeOutput
   (xs :: RL.RowList) (row :: # Type) (from :: # Type) (to :: # Type)
   | xs -> from to where
-  inputFieldToMaybeOutputBuilder :: RLProxy xs -> Record row -> Builder { | from } { | to }
+  inputFieldToMaybeOutputBuilder :: RLProxy xs -> Record row -> Maybe (Builder { | from } { | to })
 
 instance inputFieldToMaybeOutputNil :: InputFieldToMaybeOutput RL.Nil row () () where
-  inputFieldToMaybeOutputBuilder _ _ = identity
+  inputFieldToMaybeOutputBuilder _ _ = Just identity
 
 instance inputFieldToMaybeOutputCons
   :: ( IsSymbol name
      , Row.Cons name (InputField i e o) trash row
      , InputFieldToMaybeOutput tail row from from'
      , Row.Lacks name from'
-     , Row.Cons name (MaybeOutput i e o) from' to
+     , Row.Cons name (OutputField i e o) from' to
      )
   => InputFieldToMaybeOutput (RL.Cons name (InputField i e o) tail) row from to where
   inputFieldToMaybeOutputBuilder _ r =
-    first <<< rest
-    where
-      _name = SProxy :: SProxy name
-      val = transform $ Record.get _name r
-      rest = inputFieldToMaybeOutputBuilder (RLProxy :: RLProxy tail) r
-      first = Builder.insert _name val
-      transform (InputField { result }) = MaybeOutput
-        case result of
-          Just (Right v) -> Just v
-          _ -> Nothing
-
-
--- | The class that provides the Builder implementation to efficiently transform the record
--- | of MaybeOutput to a record of OutputField, but only if all fields were successfully
--- | validated.
-class MaybeOutputToOutputField
-  (xs :: RL.RowList) (row :: # Type) (from :: # Type) (to :: # Type)
-  | xs -> from to where
-  maybeOutputToOutputFieldBuilder :: RLProxy xs -> Record row -> Maybe (Builder { | from } { | to })
-
-instance maybeOutputToOutputFieldNil :: MaybeOutputToOutputField RL.Nil row () () where
-  maybeOutputToOutputFieldBuilder _ _ = Just identity
-
-instance maybeOutputToOutputFieldCons
-  :: ( IsSymbol name
-     , Newtype (MaybeOutput i e o) (Maybe o)
-     , Row.Cons name (MaybeOutput i e o) trash row
-     , MaybeOutputToOutputField tail row from from'
-     , Row.Lacks name from'
-     , Row.Cons name (OutputField i e o) from' to
-     )
-  => MaybeOutputToOutputField (RL.Cons name (MaybeOutput i e o) tail) row from to where
-  maybeOutputToOutputFieldBuilder _ r =
     transform <$> val <*> rest
     where
       _name = SProxy :: SProxy name
 
       val :: Maybe (OutputField i e o)
-      val = map OutputField $ unwrap $ Record.get _name r
+      val = map OutputField $ join $ map hush $ _.result $ unwrap $ Record.get _name r
 
       rest :: Maybe (Builder { | from } { | from' })
-      rest = maybeOutputToOutputFieldBuilder (RLProxy :: RLProxy tail) r
+      rest = inputFieldToMaybeOutputBuilder (RLProxy :: RLProxy tail) r
 
       transform
         :: OutputField i e o


### PR DESCRIPTION
## What does this pull request do?

This PR introduces a major change to Formless: the form component now manages submissions on your behalf, only notifying you when the form has been successfully submitted.

It also introduces more useful state internally and publicly, reduces the number of output messages for end users to handle, and fixes a few bugs related to managing 'touched', 'dirty', and 'valid' states.

## How should this be manually tested?

Run through the examples in the DOM and verify they behave as expected.