### PR TITLE
Add support for multiple child slots

### DIFF
--- a/example/real-world/Component.purs
+++ b/example/real-world/Component.purs
@@ -109,8 +109,33 @@ component =
     -- We can reset both forms to their starting values by leveraging
     -- the `Reset` query from Formless. We also need to reset our various
     -- external components, as Formless doesn't know about them.
-    -- TODO: Currently can't send queries through to multiple child types
     Reset a -> do
+      -- To send a query through to a child component when Formless has multiple
+      -- child component types, use send'
+      _ <- H.query' CP.cp1 unit
+        $ H.action
+        $ Formless.send' CP.cp1 WhiskeyTypeahead
+        $ TA.ReplaceSelections (TA.One Nothing) unit
+      _ <- H.query' CP.cp1 unit
+        $ H.action
+        $ Formless.send' CP.cp1 ApplicationsTypeahead
+        $ TA.ReplaceSelections (TA.Many []) unit
+      _ <- H.query' CP.cp1 unit
+        $ H.action
+        $ Formless.send' CP.cp1 PixelsTypeahead
+        $ TA.ReplaceSelections (TA.Many []) unit
+      _ <- H.query' CP.cp1 unit
+        $ H.action
+        $ Formless.send' CP.cp2 unit
+        $ Dropdown.SetSelection Nothing unit
+
+      -- On the Options form, there is no child path to worry about, so we can stick
+      -- with the usual data constructor.
+      _ <- H.query' CP.cp2 unit
+        $ H.action
+        $ Formless.Send unit (Dropdown.SetSelection Nothing unit)
+
+      -- Finally, we can trigger a simple Formless reset on each form.
       _ <- H.query' CP.cp1 unit $ H.action Formless.Reset
       _ <- H.query' CP.cp2 unit $ H.action Formless.Reset
       pure a

--- a/src/Formless.purs
+++ b/src/Formless.purs
@@ -24,6 +24,7 @@ import Formless.Internal as Internal
 import Formless.Spec (FormSpec, InputField, OutputField)
 import Formless.Spec as FSpec
 import Halogen as H
+import Halogen.Component.ChildPath (ChildPath, injQuery, injSlot)
 import Halogen.HTML as HH
 import Halogen.HTML.Events as HE
 import Halogen.HTML.Properties as HP
@@ -309,9 +310,21 @@ component =
     pure $ _.formResult $ unwrap result.internal
 
 
+
 --------------------
 -- External to the component
 --------------------
+
+-- | When you are using several different types of child components in Formless
+-- | the component needs a child path to be able to pick the right slot to send
+-- | a query to.
+send' :: ∀ pq cq' cs' cs cq form out m a
+  . ChildPath cq cq' cs cs'
+ -> cs
+ -> cq Unit
+ -> a
+ -> Query pq cq' cs' form out m a
+send' path p q = Send (injSlot path p) (injQuery path q)
 
 -- | Handles resetting a single field, but is only possible if the field is
 -- | a member of the Initial type class


### PR DESCRIPTION
## What does this pull request do?

Fixes https://github.com/thomashoneyman/purescript-halogen-formless/issues/4 by providing a new `send'` function from the Formless module. Thanks to @monoidmusician for the idea.

## Where should the reviewer start?

Note how the `real-world` example is now able to properly reset various types of child components, and check the `Formless` file to see the new `send'` function. It's nearly the same as the Halogen `query'` function.

## How should this be manually tested?

Verify that filling out a few external components in the `/real-world` example and then resetting the form resets all the components properly.

## Other Notes:

Halogen v5.0.0 introduces a new way to manage slots for components. That will impact how passing queries through ought to be handled, though @monoidmusician has an example in [purescript-halogen-zuruzuru](https://github.com/MonoidMusician/purescript-halogen-zuruzuru)

