### PR TITLE
Improve type inference

### DIFF
--- a/example/basic/Component.purs
+++ b/example/basic/Component.purs
@@ -35,8 +35,8 @@ type Contact =
 -- | The same type represented as a form: the possible input,
 -- | error, and output types for each field.
 newtype Form f = Form
-  { name :: f String (NonEmptyList FieldError) String
-  , text :: f String Void String
+  { name :: f (NonEmptyList FieldError) String String
+  , text :: f Void String String
   }
 derive instance newtypeForm :: Newtype (Form f) _
 
@@ -44,6 +44,7 @@ derive instance newtypeForm :: Newtype (Form f) _
 -- | for each field.
 _name = SProxy :: SProxy "name"
 _text = SProxy :: SProxy "text"
+
 
 -- | The initial values for the form, which you must provide. If
 -- | this seems tedious, it is! For a much less boilerplate-heavy

--- a/example/external-components/Spec.purs
+++ b/example/external-components/Spec.purs
@@ -24,10 +24,10 @@ type User = Record (FormRow Output)
 -- | We'll use this row to generate our form spec, but also to represent the
 -- | available fields in the record.
 type FormRow f =
-  ( name     :: f String         V.Errs String
-  , email    :: f (Maybe String) V.Errs String
-  , whiskey  :: f (Maybe String) V.Errs String
-  , language :: f (Maybe String) V.Errs String
+  ( name     :: f V.Errs String         String
+  , email    :: f V.Errs (Maybe String) String
+  , whiskey  :: f V.Errs (Maybe String) String
+  , language :: f V.Errs (Maybe String) String
   )
 
 -- | You'll usually want symbol proxies for convenience

--- a/example/polyform/Spec.purs
+++ b/example/polyform/Spec.purs
@@ -54,22 +54,18 @@ formSpec = mkFormSpecFromRow $ RProxy :: RProxy (FormRow Input)
 
 -- | You should provide your own validation. This example uses the composable
 -- | validation toolkit `purescript-polyform`
-validator :: forall m. MonadEffect m => Form InputField -> m (Form InputField)
+validator :: ∀ m. MonadEffect m => Form InputField -> m (Form InputField)
 validator = applyOnInputFields
-  ( Form
-    { name: Name <$> (minLength 5 *> maxLength 10)
-    , email: emailFormat >>> emailIsUsed
-    , city: minLength 0
-    , state: Validation.hoistFnV pure
-    }
-  )
+  { name: Name <$> (minLength 5 *> maxLength 10)
+  , email: emailFormat >>> emailIsUsed
+  , city: minLength 0
+  , state: Validation.hoistFnV pure
+  }
 
 -- | You should provide a function from the form with only output values to your ideal
 -- | parsed type.
 submitter :: ∀ m. Monad m => Form OutputField -> m User
 submitter = pure <<< unwrapOutput
-
-
 
 ----------
 -- Validation via Polyform

--- a/example/polyform/Spec.purs
+++ b/example/polyform/Spec.purs
@@ -7,15 +7,14 @@ import Data.String (Pattern(..), contains, length)
 import Data.Symbol (SProxy(..))
 import Data.Tuple (Tuple(..))
 import Data.Variant (Variant, inj)
-import Effect.Aff (Aff)
-import Effect.Class (liftEffect)
+import Effect.Class (class MonadEffect, liftEffect)
 import Effect.Random (random)
 import Formless.Spec (FormSpec, Input, InputField, Output, OutputField)
 import Formless.Spec.Transform (mkFormSpecFromRow, unwrapOutput)
 import Formless.Validation.Polyform (applyOnInputFields)
 import Polyform.Validation (V(..), Validation(..))
 import Polyform.Validation as Validation
-import Type.Row (RProxy(..))
+import Type.Row (type (+), RProxy(..))
 
 -- | Our overall form type, derived from the form row.
 newtype Form f = Form (Record (FormRow f))
@@ -36,10 +35,10 @@ type User = Record (FormRow Output)
 -- | We'll use this row to generate our form spec, but also to represent the
 -- | available fields in the record.
 type FormRow f =
-  ( name  :: f String (Errs (minLength :: Tuple Int String, maxLength :: Tuple Int String)) Name
-  , email :: f String (Errs (emailFormat :: String, emailIsUsed :: Email)) Email
-  , city  :: f String (Errs (minLength :: Tuple Int String)) String
-  , state :: f String (Errs (minLength :: Tuple Int String)) String
+  ( name  :: f (Errs (Min + Max ()))       String Name
+  , email :: f (Errs (EFormat + EUsed ())) String Email
+  , city  :: f (Errs (Min ()))             String String
+  , state :: f (Errs ())                   String String
   )
 
 -- | You'll usually want symbol proxies for convenience
@@ -55,13 +54,15 @@ formSpec = mkFormSpecFromRow $ RProxy :: RProxy (FormRow Input)
 
 -- | You should provide your own validation. This example uses the composable
 -- | validation toolkit `purescript-polyform`
-validator :: Form InputField -> Aff (Form InputField)
+validator :: forall m. MonadEffect m => Form InputField -> m (Form InputField)
 validator = applyOnInputFields
-  { name: Name <$> (minLength 5 *> maxLength 10)
-  , email: emailFormat >>> emailIsUsed
-  , city: minLength 0
-  , state: minLength 0
-  }
+  ( Form
+    { name: Name <$> (minLength 5 *> maxLength 10)
+    , email: emailFormat >>> emailIsUsed
+    , city: minLength 0
+    , state: Validation.hoistFnV pure
+    }
+  )
 
 -- | You should provide a function from the form with only output values to your ideal
 -- | parsed type.
@@ -74,6 +75,10 @@ submitter = pure <<< unwrapOutput
 -- Validation via Polyform
 
 type Errs r = Array (Variant r)
+type EFormat r = (emailFormat :: String | r)
+type EUsed r = (emailIsUsed :: Email | r)
+type Min r = (minLength :: Tuple Int String | r)
+type Max r = (maxLength :: Tuple Int String | r)
 
 -- | This is a pure validator, so we'll leave `m` polymorphic. It parses to a different
 -- | output type than its input: an email
@@ -91,8 +96,9 @@ emailFormat = Validation.hoistFnV \e →
 -- | is in use (faked with `random`). It expects that the email being validated is
 -- | already valid.
 emailIsUsed
-  :: ∀ r
-   . Validation Aff (Array (Variant (emailIsUsed :: Email | r))) Email Email
+  :: ∀ r m
+   . MonadEffect m
+  => Validation m (Array (Variant (emailIsUsed :: Email | r))) Email Email
 emailIsUsed = Validation \e -> do
   v <- liftEffect random
   pure $ if v > 0.5

--- a/example/real-world/Data/Group.purs
+++ b/example/real-world/Data/Group.purs
@@ -43,21 +43,18 @@ derive newtype instance showAdmin :: Show Admin
 -- | have only one, and of a different name altogether.
 -- |
 -- | In order to be able to define a form, you'll need to leave a type variable
--- | free that takes 3 types as arguments: the input (what the user provides),
--- | error type (produced by validation), and output (what results from
--- | successful validation).
+-- | free that takes 3 types as arguments: the error, input, and output types.
 -- |
 -- | In order for this row to be extensible, you'll need another type variable open
 -- | to take possible additional rows
--- |                  Input          Error Output
 type GroupRow f r =
-  ( name         :: f String         Errs String
-  , admin        :: f (Maybe Admin)  Errs Admin
-  , applications :: f (Array String) Errs (Array String)
-  , pixels       :: f (Array String) Errs (Array String)
-  , maxBudget    :: f String         Errs (Maybe Int)
-  , minBudget    :: f String         Errs Int
-  , whiskey      :: f (Maybe String) Errs String
+  ( name         :: f Errs String         String
+  , admin        :: f Errs (Maybe Admin)  Admin
+  , applications :: f Errs (Array String) (Array String)
+  , pixels       :: f Errs (Array String) (Array String)
+  , maxBudget    :: f Errs String         (Maybe Int)
+  , minBudget    :: f Errs String         Int
+  , whiskey      :: f Errs (Maybe String) String
   | r
   )
 

--- a/example/real-world/Data/Group.purs
+++ b/example/real-world/Data/Group.purs
@@ -105,8 +105,8 @@ derive instance newtypeGroupForm :: Newtype (GroupForm f) _
 -- | In order to generate our fields automatically using mkFormSpecFromRow, we'll make
 -- | sure to have the new row as a new type.
 type GroupFormRow f = GroupRow f
-  ( secretKey1 :: f String Errs String
-  , secretKey2 :: f String Errs String
+  ( secretKey1 :: f Errs String String
+  , secretKey2 :: f Errs String String
   )
 
 _secretKey1 = SProxy :: SProxy "secretKey1"

--- a/example/real-world/Data/Options.purs
+++ b/example/real-world/Data/Options.purs
@@ -71,14 +71,14 @@ instance initialSpeed :: Initial Speed where
 -- | closed row. In the case of the 'enable' option, we know there's no validation
 -- | for it, so we'll use `Void` as the error type.
 type OptionsRow f =
-  ( enable       :: f Boolean        Void Boolean
-  , metric       :: f (Maybe Metric) Errs Metric
-  , viewCost     :: f String         Errs (Maybe Dollars)
-  , clickCost    :: f String         Errs (Maybe Dollars)
-  , installCost  :: f String         Errs (Maybe Dollars)
-  , size         :: f String         Errs Number
-  , dimensions   :: f String         Errs Number
-  , speed        :: f Speed          Void Speed
+  ( enable       :: f Unit Boolean        Boolean
+  , metric       :: f Errs (Maybe Metric) Metric
+  , viewCost     :: f Errs String         (Maybe Dollars)
+  , clickCost    :: f Errs String         (Maybe Dollars)
+  , installCost  :: f Errs String         (Maybe Dollars)
+  , size         :: f Errs String         Number
+  , dimensions   :: f Errs String         Number
+  , speed        :: f Unit Speed          Speed
   )
 
 _enable = SProxy :: SProxy "enable"

--- a/example/real-world/Render/Field.purs
+++ b/example/real-world/Render/Field.purs
@@ -45,7 +45,7 @@ input
    . IsSymbol sym
   => Show e
   => Newtype (form InputField) (Record fields)
-  => Cons sym (InputField String e o) t0 fields
+  => Cons sym (InputField e String o) t0 fields
   => FieldConfig sym
   -> FieldType
   -> Formless.State form out m
@@ -74,7 +74,7 @@ formField
    . IsSymbol sym
   => Show e
   => Newtype (form InputField) (Record fields)
-  => Cons sym (InputField i e o) t0 fields
+  => Cons sym (InputField e i o) t0 fields
   => Formless.State form out m
   -> FieldConfig sym
   -> ( { result :: Maybe (Either e o)

--- a/example/real-world/Render/GroupForm.purs
+++ b/example/real-world/Render/GroupForm.purs
@@ -52,9 +52,9 @@ render state =
     , Card.card_
       [ Format.subHeading_
         [ HH.text "Applications & Pixels" ]
-      , renderApplications state
-      , renderPixels state
-      , renderWhiskey state
+      --  , renderApplications state
+      --  , renderPixels state
+      --  , renderWhiskey state
       ]
     , Card.card_
       [ Format.subHeading_
@@ -169,7 +169,7 @@ renderPixels =
     { label: "Pixels"
     , placeholder: Just "My unique pixel"
     , helpText: "Select one or more tracking pixels for the group."
-    , field: G._name
+    , field: G._pixels
     }
     [ "My favorite pixel"
     , "Your favorite pixel"
@@ -185,7 +185,7 @@ renderApplications =
    { label: "Applications"
    , placeholder: Just "Facebook"
    , helpText: "Select one or more applications for the group."
-   , field: G._name
+   , field: G._applications
    }
    [ "Facebook", "Google", "Twitter", "Pinterest" ]
 
@@ -238,7 +238,7 @@ multiTypeahead
    . IsSymbol sym
   => Show e
   => Newtype (G.GroupForm InputField) (Record fields)
-  => Cons sym (InputField String e o) t0 fields
+  => Cons sym (InputField e (Array String) o) t0 fields
   => GroupTASlot
   -> (GroupTASlot -> TA.Message Query String -> Unit -> Query Unit)
   -> FieldConfig sym

--- a/example/real-world/Spec/GroupForm.purs
+++ b/example/real-world/Spec/GroupForm.purs
@@ -6,7 +6,7 @@ import Data.List.NonEmpty (NonEmptyList)
 import Data.Maybe (Maybe(..))
 import Data.Symbol (SProxy(..))
 import Data.Validation.Semigroup (V)
-import Example.RealWorld.Data.Group (Admin, Group(..), GroupForm, GroupFormRow, GroupId(..), _secretKey1, _secretKey2)
+import Example.RealWorld.Data.Group (Admin, Group(..), GroupForm(..), GroupFormRow, GroupId(..), _secretKey1, _secretKey2)
 import Example.Utils as V
 import Formless.Spec (OutputField, getInput)
 import Formless.Spec as Spec

--- a/example/real-world/Spec/GroupForm.purs
+++ b/example/real-world/Spec/GroupForm.purs
@@ -6,7 +6,7 @@ import Data.List.NonEmpty (NonEmptyList)
 import Data.Maybe (Maybe(..))
 import Data.Symbol (SProxy(..))
 import Data.Validation.Semigroup (V)
-import Example.RealWorld.Data.Group (Admin, Group(..), GroupForm(..), GroupFormRow, GroupId(..), _secretKey1, _secretKey2)
+import Example.RealWorld.Data.Group (Admin, Group(..), GroupForm, GroupFormRow, GroupId(..), _secretKey1, _secretKey2)
 import Example.Utils as V
 import Formless.Spec (OutputField, getInput)
 import Formless.Spec as Spec

--- a/src/Formless.purs
+++ b/src/Formless.purs
@@ -375,7 +375,7 @@ send' path p q = Send (injSlot path p) (injQuery path q)
 modify
   :: ∀ sym pq cq cs out m form form' i e o r
    . IsSymbol sym
-  => Cons sym (InputField i e o) r form
+  => Cons sym (InputField e i o) r form
   => Newtype (form' InputField) (Record form)
   => SProxy sym
   -> (i -> i)
@@ -384,17 +384,17 @@ modify sym f = HandleChange (modify' sym f) unit
 
 -- | Allows you to modify a field rather than set its value
 modify'
-  :: ∀ sym form form' inp err out r
+  :: ∀ sym form form' e i o r
    . IsSymbol sym
-  => Cons sym (InputField inp err out) r form
+  => Cons sym (InputField e i o) r form
   => Newtype form' (Record form)
   => SProxy sym
-  -> (inp -> inp)
+  -> (i -> i)
   -> form'
   -> form'
 modify' sym f = wrap <<< setInput f <<< setTouched true <<< unwrap
   where
-    _sym :: Lens.Lens' (Record form) (InputField inp err out)
+    _sym :: Lens.Lens' (Record form) (InputField e i o)
     _sym = prop sym
     setInput =
       Lens.over (_sym <<< _Newtype <<< prop FSpec._input)
@@ -406,7 +406,7 @@ modify' sym f = wrap <<< setInput f <<< setTouched true <<< unwrap
 handleReset
   :: ∀ pq cq cs m sym form' form i e o out r
    . IsSymbol sym
-  => Cons sym (InputField i e o) r form
+  => Cons sym (InputField e i o) r form
   => Newtype (form' InputField) (Record form)
   => Initial i
   => SProxy sym
@@ -416,7 +416,7 @@ handleReset sym = HandleReset (handleReset' sym) unit
 handleReset'
   :: ∀ sym form' form i e o r
    . IsSymbol sym
-  => Cons sym (InputField i e o) r form
+  => Cons sym (InputField e i o) r form
   => Newtype form' (Record form)
   => Initial i
   => SProxy sym
@@ -424,7 +424,7 @@ handleReset'
   -> form'
 handleReset' sym = wrap <<< unsetTouched <<< unsetResult <<< unsetValue <<< unwrap
   where
-    _sym :: Lens.Lens' (Record form) (InputField i e o)
+    _sym :: Lens.Lens' (Record form) (InputField e i o)
     _sym = prop sym
     unsetTouched = Lens.set (_sym <<< _Newtype <<< prop FSpec._touched) false
     unsetResult = Lens.set (_sym <<< _Newtype <<< prop FSpec._result) Nothing
@@ -433,7 +433,7 @@ handleReset' sym = wrap <<< unsetTouched <<< unsetResult <<< unsetValue <<< unwr
 onClickWith
   :: ∀ pq cq cs m sym form' form i e o out r props
    . IsSymbol sym
-  => Cons sym (InputField i e o) r form
+  => Cons sym (InputField e i o) r form
   => Newtype (form' InputField) (Record form)
   => SProxy sym
   -> i
@@ -445,7 +445,7 @@ onClickWith sym i =
 handleBlurAndChange
   :: ∀ pq cq cs m sym form' form i e o out r
    . IsSymbol sym
-  => Cons sym (InputField i e o) r form
+  => Cons sym (InputField e i o) r form
   => Newtype (form' InputField) (Record form)
   => SProxy sym
   -> i
@@ -457,7 +457,7 @@ handleBlurAndChange sym val = HandleBlur (handleBlur' sym <<< handleChange' sym 
 onBlurWith
   :: ∀ pq cq cs m sym form' form i e o out r props
    . IsSymbol sym
-  => Cons sym (InputField i e o) r form
+  => Cons sym (InputField e i o) r form
   => Newtype (form' InputField) (Record form)
   => SProxy sym
   -> HP.IProp (onBlur :: FocusEvent | props) (Query pq cq cs form' out m Unit)
@@ -466,7 +466,7 @@ onBlurWith sym = HE.onBlur $ const $ Just $ handleBlur sym
 handleBlur
   :: ∀ pq cq cs m sym form' form i e o out r
    . IsSymbol sym
-  => Cons sym (InputField i e o) r form
+  => Cons sym (InputField e i o) r form
   => Newtype (form' InputField) (Record form)
   => SProxy sym
   -> Query pq cq cs form' m out Unit
@@ -475,14 +475,14 @@ handleBlur sym = HandleBlur (handleBlur' sym) unit
 handleBlur'
   :: ∀ sym form' form i e o r
    . IsSymbol sym
-  => Cons sym (InputField i e o) r form
+  => Cons sym (InputField e i o) r form
   => Newtype form' (Record form)
   => SProxy sym
   -> form'
   -> form'
 handleBlur' sym form = wrap <<< setTouched $ unwrap form
   where
-    _sym :: Lens.Lens' (Record form) (InputField i e o)
+    _sym :: Lens.Lens' (Record form) (InputField e i o)
     _sym = prop sym
     setTouched = Lens.set (_sym <<< _Newtype <<< prop FSpec._touched) true
 
@@ -490,7 +490,7 @@ handleBlur' sym form = wrap <<< setTouched $ unwrap form
 onValueInputWith
   :: ∀ pq cq cs m sym form' form e o out r props
    . IsSymbol sym
-  => Cons sym (InputField String e o) r form
+  => Cons sym (InputField e String o) r form
   => Newtype (form' InputField) (Record form)
   => SProxy sym
   -> HP.IProp (onInput :: Event, value :: String | props) (Query pq cq cs form' out m Unit)
@@ -500,7 +500,7 @@ onValueInputWith sym =
 onValueChangeWith
   :: ∀ pq cq cs m sym form' form e o out r props
    . IsSymbol sym
-  => Cons sym (InputField String e o) r form
+  => Cons sym (InputField e String o) r form
   => Newtype (form' InputField) (Record form)
   => SProxy sym
   -> HP.IProp (onChange :: Event, value :: String | props) (Query pq cq cs form' out m Unit)
@@ -510,7 +510,7 @@ onValueChangeWith sym =
 onChangeWith
   :: ∀ pq cq cs m sym form' form i e o out r props
    . IsSymbol sym
-  => Cons sym (InputField i e o) r form
+  => Cons sym (InputField e i o) r form
   => Newtype (form' InputField) (Record form)
   => SProxy sym
   -> i
@@ -521,7 +521,7 @@ onChangeWith sym i =
 handleChange
   :: ∀ pq cq cs m sym form' form i e o out r
    . IsSymbol sym
-  => Cons sym (InputField i e o) r form
+  => Cons sym (InputField e i o) r form
   => Newtype (form' InputField) (Record form)
   => SProxy sym
   -> i
@@ -529,17 +529,17 @@ handleChange
 handleChange sym val = HandleChange (handleChange' sym val) unit
 
 handleChange'
-  :: ∀ sym form form' inp err out r
+  :: ∀ sym form form' e i o r
    . IsSymbol sym
-  => Cons sym (InputField inp err out) r form
+  => Cons sym (InputField e i o) r form
   => Newtype form' (Record form)
   => SProxy sym
-  -> inp
+  -> i
   -> form'
   -> form'
 handleChange' sym val = wrap <<< setInput val <<< setTouched true <<< unwrap
   where
-    _sym :: Lens.Lens' (Record form) (InputField inp err out)
+    _sym :: Lens.Lens' (Record form) (InputField e i o)
     _sym = prop sym
     setInput =
       Lens.set (_sym <<< _Newtype <<< prop FSpec._input)

--- a/src/Internal/Internal.purs
+++ b/src/Internal/Internal.purs
@@ -14,7 +14,6 @@ import Record as Record
 import Record.Builder (Builder)
 import Record.Builder as Builder
 import Type.Data.RowList (RLProxy(..))
-import Type.Row (class ListToRow)
 
 -----
 -- Types
@@ -37,18 +36,14 @@ class (Row.Cons s t r r', Row.Lacks s r) <= Row1Cons s t r r' | s t r -> r', s r
 instance row1Cons :: (Row.Cons s t r r', Row.Lacks s r) => Row1Cons s t r r'
 
 -- | @monoidmusician
-class (RL.RowToList r rl, ListToRow rl r) <= RowRowList r rl | r -> rl, rl -> r
-instance rowRowList :: (RL.RowToList r rl, ListToRow rl r) => RowRowList r rl
-
--- | @monoidmusician
-class (Row1Cons s t r r', RowRowList r rl, RowRowList r' rl')
+class (Row1Cons s t r r', RL.RowToList r rl, RL.RowToList r' rl')
   <= Row3 s t r r' rl rl'
   | rl' -> s t r r' rl
   , rl -> r
   , s t r -> r' rl rl'
   , s t rl -> r r' rl'
 instance row3 ::
-  (Row1Cons s t r r', RowRowList r rl, RowRowList r' (RL.Cons s t rl))
+  (Row1Cons s t r r', RL.RowToList r rl, RL.RowToList r' (RL.Cons s t rl))
   => Row3 s t r r' rl (RL.Cons s t rl)
 
 -----
@@ -422,9 +417,9 @@ class ApplyRecord (io :: # Type) (i :: # Type) (o :: # Type)
   applyRecord :: Record io -> Record i -> Record o
 
 instance applyRecordImpl
-  :: ( RowRowList io lio
-     , RowRowList i li
-     , RowRowList o lo
+  :: ( RL.RowToList io lio
+     , RL.RowToList i li
+     , RL.RowToList o lo
      , ApplyRowList lio li lo io i io i o
      )
   => ApplyRecord io i o where
@@ -442,9 +437,9 @@ instance applyRecordImpl
 -- | Applies a record of functions to a record of input values to produce
 -- | a record of outputs.
 class
-  ( RowRowList ior io
-  , RowRowList ir i
-  , RowRowList or o
+  ( RL.RowToList ior io
+  , RL.RowToList ir i
+  , RL.RowToList or o
   ) <=
   ApplyRowList
     (io :: RL.RowList)
@@ -476,8 +471,6 @@ instance applyRowListCons
      , Row3 k (i -> o) tior ior tio (RL.Cons k (i -> o) tio)
      , Row3 k i tir ir ti (RL.Cons k i ti)
      , Row3 k o tor or to (RL.Cons k o to)
-     , ListToRow (RL.Cons k (i -> o) tio) ior
-     , ListToRow (RL.Cons k i ti) ir
      , ApplyRowList tio ti to tior tir iorf irf tor
      , IsSymbol k
      )

--- a/src/Internal/Internal.purs
+++ b/src/Internal/Internal.purs
@@ -21,9 +21,9 @@ import Type.Row (class ListToRow)
 
 -- | Never exposed to the user, but used to aid equality instances for
 -- | checking dirty states.
-newtype Input i e o = Input i
-derive instance newtypeInput :: Newtype (Input i e o) _
-derive newtype instance eqInput :: Eq i => Eq (Input i e o)
+newtype Input e i o = Input i
+derive instance newtypeInput :: Newtype (Input e i o) _
+derive newtype instance eqInput :: Eq i => Eq (Input e i o)
 
 -- | Represents building some output record from an empty record
 type FromScratch r = Builder {} (Record r)
@@ -179,11 +179,11 @@ instance setInputFieldsTouchedNil :: SetInputFieldsTouched RL.Nil row () where
 
 instance setInputFieldsTouchedCons
   :: ( IsSymbol name
-     , Row.Cons name (InputField i e o) trash row
-     , Row1Cons name (InputField i e o) from to
+     , Row.Cons name (InputField e i o) trash row
+     , Row1Cons name (InputField e i o) from to
      , SetInputFieldsTouched tail row from
      )
-  => SetInputFieldsTouched (RL.Cons name (InputField i e o) tail) row to where
+  => SetInputFieldsTouched (RL.Cons name (InputField e i o) tail) row to where
   setInputFieldsTouchedBuilder _ r =
     first <<< rest
     where
@@ -203,11 +203,11 @@ instance inputFieldsToInputNil :: InputFieldsToInput RL.Nil row () where
 
 instance inputFieldsToInputCons
   :: ( IsSymbol name
-     , Row.Cons name (InputField i e o) trash row
+     , Row.Cons name (InputField e i o) trash row
      , InputFieldsToInput tail row from
-     , Row1Cons name (Input i e o) from to
+     , Row1Cons name (Input e i o) from to
      )
-  => InputFieldsToInput (RL.Cons name (InputField i e o) tail) row to where
+  => InputFieldsToInput (RL.Cons name (InputField e i o) tail) row to where
   inputFieldsToInputBuilder _ r =
     first <<< rest
     where
@@ -227,11 +227,11 @@ instance formSpecToInputFieldNil :: FormSpecToInputField RL.Nil row () where
 
 instance formSpecToInputFieldCons
   :: ( IsSymbol name
-     , Row.Cons name (FormSpec i e o) trash row
+     , Row.Cons name (FormSpec e i o) trash row
      , FormSpecToInputField tail row from
-     , Row1Cons name (InputField i e o) from to
+     , Row1Cons name (InputField e i o) from to
      )
-  => FormSpecToInputField (RL.Cons name (FormSpec i e o) tail) row to where
+  => FormSpecToInputField (RL.Cons name (FormSpec e i o) tail) row to where
   formSpecToInputFieldBuilder _ r =
     first <<< rest
     where
@@ -256,23 +256,23 @@ instance inputFieldToMaybeOutputNil :: InputFieldToMaybeOutput RL.Nil row () whe
 
 instance inputFieldToMaybeOutputCons
   :: ( IsSymbol name
-     , Row.Cons name (InputField i e o) trash row
+     , Row.Cons name (InputField e i o) trash row
      , InputFieldToMaybeOutput tail row from
-     , Row1Cons name (OutputField i e o) from to
+     , Row1Cons name (OutputField e i o) from to
      )
-  => InputFieldToMaybeOutput (RL.Cons name (InputField i e o) tail) row to where
+  => InputFieldToMaybeOutput (RL.Cons name (InputField e i o) tail) row to where
   inputFieldToMaybeOutputBuilder _ r =
     transform <$> val <*> rest
     where
       _name = SProxy :: SProxy name
 
-      val :: Maybe (OutputField i e o)
+      val :: Maybe (OutputField e i o)
       val = map OutputField $ join $ map hush $ _.result $ unwrap $ Record.get _name r
 
       rest :: Maybe (FromScratch from)
       rest = inputFieldToMaybeOutputBuilder (RLProxy :: RLProxy tail) r
 
-      transform :: OutputField i e o -> FromScratch from -> FromScratch to
+      transform :: OutputField e i o -> FromScratch from -> FromScratch to
       transform v builder' = Builder.insert _name v <<< builder'
 
 -- | A class to sum a monoidal record
@@ -306,11 +306,11 @@ instance countErrorsNil :: CountErrors RL.Nil row () where
 
 instance countErrorsCons
   :: ( IsSymbol name
-     , Row.Cons name (InputField i e o) trash row
+     , Row.Cons name (InputField e i o) trash row
      , CountErrors tail row from
      , Row1Cons name (Additive Int) from to
      )
-  => CountErrors (RL.Cons name (InputField i e o) tail) row to where
+  => CountErrors (RL.Cons name (InputField e i o) tail) row to where
   countErrorsBuilder _ r =
     first <<< rest
     where
@@ -333,10 +333,10 @@ instance nilAllTouched :: AllTouched RL.Nil r where
 
 instance consAllTouched
   :: ( IsSymbol name
-     , Row.Cons name (InputField i e o) t0 r
+     , Row.Cons name (InputField e i o) t0 r
      , AllTouched tail r
      )
-  => AllTouched (RL.Cons name (InputField i e o) tail) r
+  => AllTouched (RL.Cons name (InputField e i o) tail) r
   where
     allTouchedImpl _ r =
       if (unwrap (Record.get (SProxy :: SProxy name) r)).touched

--- a/src/Spec/Spec.purs
+++ b/src/Spec/Spec.purs
@@ -13,23 +13,23 @@ import Record as Record
 -- | create the spec form that we'll compare against to measure
 -- | 'touched' states, etc. This is what the user is responsible
 -- | for providing.
-newtype FormSpec input error output = FormSpec input
-derive instance newtypeFormSpec :: Newtype (FormSpec i e o) _
+newtype FormSpec error input output = FormSpec input
+derive instance newtypeFormSpec :: Newtype (FormSpec e i o) _
 
 -- | A wrapper to represent only the output type. Used to represent
 -- | form results at the end of validation.
-newtype OutputField input error output = OutputField output
-derive instance newtypeOutputField :: Newtype (OutputField i e o) _
+newtype OutputField error input output = OutputField output
+derive instance newtypeOutputField :: Newtype (OutputField e i o) _
 
 -- | The type that we need to record state across the form, but
 -- | we don't need this from the user -- we can fill in 'touched'
 -- | and 'result' on their behalf.
-newtype InputField input error output = InputField
+newtype InputField error input output = InputField
   { input :: input
   , touched :: Boolean -- Whether the field has been changed by the user
   , result :: Maybe (Either error output)
   }
-derive instance newtypeInputField :: Newtype (InputField i e o) _
+derive instance newtypeInputField :: Newtype (InputField e i o) _
 
 -- | Proxies for each of the fields in InputField and FormSpec for easy access
 _input = SProxy :: SProxy "input"
@@ -38,11 +38,11 @@ _result = SProxy :: SProxy "result"
 
 -- | Easy access to any given field from the form, unwrapped
 getField
-  :: ∀ sym form t0 field fields i e o
+  :: ∀ sym form t0 field fields e i o
    . IsSymbol sym
   => Newtype (form InputField) (Record fields)
-  => Cons sym (InputField i e o) t0 fields
-  => Newtype (InputField i e o) field
+  => Cons sym (InputField e i o) t0 fields
+  => Newtype (InputField e i o) field
   => SProxy sym
   -> form InputField
   -> field
@@ -51,10 +51,10 @@ getField sym form =
 
 -- | Easy access to any given field's input value from the form
 getInput
-  :: ∀ sym form t0 fields i e o
+  :: ∀ sym form t0 fields e i o
    . IsSymbol sym
   => Newtype (form InputField) (Record fields)
-  => Cons sym (InputField i e o) t0 fields
+  => Cons sym (InputField e i o) t0 fields
   => SProxy sym
   -> form InputField
   -> i
@@ -62,10 +62,10 @@ getInput sym = _.input <<< getField sym
 
 -- | Easy access to any given field's touched value from the form
 getTouched
-  :: ∀ sym form t0 fields i e o
+  :: ∀ sym form t0 fields e i o
    . IsSymbol sym
   => Newtype (form InputField) (Record fields)
-  => Cons sym (InputField i e o) t0 fields
+  => Cons sym (InputField e i o) t0 fields
   => SProxy sym
   -> form InputField
   -> Boolean
@@ -74,10 +74,10 @@ getTouched sym = _.touched <<< getField sym
 -- | Easy access to any given field's result value from the form, if the
 -- | result exists.
 getResult
-  :: ∀ sym form t0 fields i e o
+  :: ∀ sym form t0 fields e i o
    . IsSymbol sym
   => Newtype (form InputField) (Record fields)
-  => Cons sym (InputField i e o) t0 fields
+  => Cons sym (InputField e i o) t0 fields
   => SProxy sym
   -> form InputField
   -> Maybe (Either e o)
@@ -86,10 +86,10 @@ getResult sym = _.result <<< getField sym
 -- | Easy access to any given field's error from its result field in the form,
 -- | if the error exists.
 getError
-  :: ∀ sym form t0 fields i e o
+  :: ∀ sym form t0 fields e i o
    . IsSymbol sym
   => Newtype (form InputField) (Record fields)
-  => Cons sym (InputField i e o) t0 fields
+  => Cons sym (InputField e i o) t0 fields
   => SProxy sym
   -> form InputField
   -> Maybe e
@@ -100,10 +100,10 @@ getError sym form = case getResult sym form of
 -- | Easy access to any given field's output from its result field in the form,
 -- | if the output exists.
 getOutput
-  :: ∀ sym form t0 fields i e o
+  :: ∀ sym form t0 fields e i o
    . IsSymbol sym
   => Newtype (form InputField) (Record fields)
-  => Cons sym (InputField i e o) t0 fields
+  => Cons sym (InputField e i o) t0 fields
   => SProxy sym
   -> form InputField
   -> Maybe o
@@ -115,12 +115,12 @@ getOutput sym = join <<< map hush <<< getResult sym
 
 -- | A type synonym that lets you pick out just the input type from
 -- | your form row.
-type Input input error output = input
+type Input error input output = input
 
 -- | A type synonym that lets you pick out just the error type from
 -- | your form row.
-type Error input error output = error
+type Error error input output = error
 
 -- | A type synonym that lets you pick out just the output type from
 -- | your form row.
-type Output input error output = output
+type Output error input output = output

--- a/src/Spec/Transform.purs
+++ b/src/Spec/Transform.purs
@@ -107,7 +107,7 @@ instance mkFormSpecFromRowCons
      , Initial i
      , Row.Cons name i trash row
      , MakeFormSpecFromRow tail row from
-     , Internal.Row1Cons name (FormSpec i e o) from to
+     , Internal.Row1Cons name (FormSpec e i o) from to
      )
   => MakeFormSpecFromRow (RL.Cons name i tail) row to where
   mkFormSpecFromRowBuilder _ r =

--- a/src/Validation/Polyform.purs
+++ b/src/Validation/Polyform.purs
@@ -67,13 +67,13 @@ applyOnInputFields
   => Newtype (form (Validation m)) (Record fv)
   => Newtype (form InputField) (Record i)
   => Newtype (form' InputField) (Record o')
-  => form (Validation m)
+  => Record fv
   -> form InputField
   -> m (form' InputField)
 applyOnInputFields r = map wrap <<< Internal.sequenceRecord <<< Internal.applyRecord io <<< unwrap
   where
     io :: Record io
-    io = Internal.fromScratch (onInputFieldsBuilder (RLProxy :: RLProxy fvxs) (unwrap r))
+    io = Internal.fromScratch (onInputFieldsBuilder (RLProxy :: RLProxy fvxs) r)
 
 -- | The class that provides the Builder implementation to efficiently unpack a record of
 -- | output fields into a simple record of only the values.

--- a/src/Validation/Polyform.purs
+++ b/src/Validation/Polyform.purs
@@ -27,14 +27,12 @@ import Type.Row (RLProxy(..))
 -- | , email :: validateEmailRegex `onInputField` form.email
 -- | }
 -- | ```
--- |
--- | Once you have
 onInputField
   :: ∀ m e i o
    . Monad m
   => Validation m e i o
-  -> InputField i e o
-  -> m (InputField i e o)
+  -> InputField e i o
+  -> m (InputField e i o)
 onInputField validator field@(InputField i)
   | not i.touched = pure field
   | otherwise = do
@@ -66,15 +64,16 @@ applyOnInputFields
   => OnInputFields fvxs fv io
   => Internal.ApplyRecord io i o
   => Internal.SequenceRecord oxs o o' m
+  => Newtype (form (Validation m)) (Record fv)
   => Newtype (form InputField) (Record i)
   => Newtype (form' InputField) (Record o')
-  => Record fv
+  => form (Validation m)
   -> form InputField
   -> m (form' InputField)
 applyOnInputFields r = map wrap <<< Internal.sequenceRecord <<< Internal.applyRecord io <<< unwrap
   where
     io :: Record io
-    io = Builder.build (onInputFieldsBuilder (RLProxy :: RLProxy fvxs) r) {}
+    io = Internal.fromScratch (onInputFieldsBuilder (RLProxy :: RLProxy fvxs) (unwrap r))
 
 -- | The class that provides the Builder implementation to efficiently unpack a record of
 -- | output fields into a simple record of only the values.
@@ -89,7 +88,7 @@ instance onInputFieldsCons
      , Monad m
      , Row.Cons name (Validation m e i o) trash row
      , OnInputFields tail row from
-     , Internal.Row1Cons name (InputField i e o -> m (InputField i e o)) from to
+     , Internal.Row1Cons name (InputField e i o -> m (InputField e i o)) from to
      )
   => OnInputFields (RL.Cons name (Validation m e i o) tail) row to where
   onInputFieldsBuilder _ r =

--- a/src/Validation/Semigroup.purs
+++ b/src/Validation/Semigroup.purs
@@ -30,8 +30,8 @@ import Type.Row (RLProxy(..))
 onInputField
   :: ∀ i e o
    . (i -> V e o)
-  -> InputField i e o
-  -> InputField i e o
+  -> InputField e i o
+  -> InputField e i o
 onInputField validator field@(InputField i)
   | not i.touched = field
   | otherwise = InputField $ unV
@@ -87,7 +87,7 @@ instance onInputFieldsCons
      , Row.Cons name (i -> V e o) trash row
      , OnInputFields tail row from from'
      , Row.Lacks name from'
-     , Row.Cons name (InputField i e o -> InputField i e o) from' to
+     , Row.Cons name (InputField e i o -> InputField e i o) from' to
      )
   => OnInputFields (RL.Cons name (i -> V e o) tail) row from to where
   onInputFieldsBuilder _ r =

--- a/src/Validation/Semigroup.purs
+++ b/src/Validation/Semigroup.purs
@@ -14,7 +14,6 @@ import Formless.Spec (InputField(..))
 import Prim.Row as Row
 import Prim.RowList as RL
 import Record as Record
-import Record.Builder (Builder)
 import Record.Builder as Builder
 import Type.Row (RLProxy(..))
 
@@ -60,7 +59,7 @@ onInputField validator field@(InputField i)
 applyOnInputFields
   :: ∀ form form' fvxs fv io i o
    . RL.RowToList fv fvxs
-  => OnInputFields fvxs fv () io
+  => OnInputFields fvxs fv io
   => Internal.ApplyRecord io i o
   => Newtype (form InputField) (Record i)
   => Newtype (form' InputField) (Record o)
@@ -74,22 +73,19 @@ applyOnInputFields r = wrap <<< Internal.applyRecord io <<< unwrap
 
 -- | The class that provides the Builder implementation to efficiently unpack a record of
 -- | output fields into a simple record of only the values.
-class OnInputFields
-  (xs :: RL.RowList) (row :: # Type) (from :: # Type) (to :: # Type)
-  | xs -> from to where
-  onInputFieldsBuilder :: RLProxy xs -> Record row -> Builder { | from } { | to }
+class OnInputFields (xs :: RL.RowList) (row :: # Type) (to :: # Type) | xs -> to where
+  onInputFieldsBuilder :: RLProxy xs -> Record row -> Internal.FromScratch to
 
-instance onInputFieldsNil :: OnInputFields RL.Nil row () () where
+instance onInputFieldsNil :: OnInputFields RL.Nil row () where
   onInputFieldsBuilder _ _ = identity
 
 instance onInputFieldsCons
   :: ( IsSymbol name
      , Row.Cons name (i -> V e o) trash row
-     , OnInputFields tail row from from'
-     , Row.Lacks name from'
-     , Row.Cons name (InputField e i o -> InputField e i o) from' to
+     , OnInputFields tail row from
+     , Internal.Row1Cons name (InputField e i o -> InputField e i o) from to
      )
-  => OnInputFields (RL.Cons name (i -> V e o) tail) row from to where
+  => OnInputFields (RL.Cons name (i -> V e o) tail) row to where
   onInputFieldsBuilder _ r =
     first <<< rest
     where

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -12,3 +12,5 @@ main = runTest do
   suite "pure form validation" do
     test "validates" do
       pure unit
+
+checkInference = applyRecord <@> { a: identity show }


### PR DESCRIPTION
## What does this pull request do?

- Cleans up the `Internal` module (thanks to @monoidmusician) with better constraints for `applyRecord` and some stylistic improvements.
- Swaps the order of arguments to `InputField`, `FormSpec`, etc. in order to support Polyform's `Validation` type as a constraint in the `applyOnInputFields` function.

These two improvements dramatically improve type inference when writing validators for a form spec and remove most instances of the dreaded `No instance found for RowToList t2 t3`.

## Other Notes:

This is a breaking change, but the only updates dependencies need to do is flip the order of arguments in their specs.

