### PR TITLE
Fix MakeLenses

### DIFF
--- a/example/polyform/Component.purs
+++ b/example/polyform/Component.purs
@@ -11,7 +11,7 @@ import Effect.Class (class MonadEffect)
 import Effect.Console as Console
 import Example.Utils as V
 import Formless as F
-import Formless.Spec.Transform (class MakeLenses, FormLens, mkLensesFromFormSpec)
+import Formless.Spec.Transform (class MakeLenses, mkLensesFromFormSpec)
 import Formless.Validation.Polyform (applyOnInputFields)
 import Halogen as H
 import Halogen.HTML as HH
@@ -125,7 +125,7 @@ formSpec = F.mkFormSpecFromRow $ RProxy :: RProxy (FormRow F.InputType)
 lenses
   :: ∀ row xs row'
    . RL.RowToList row xs
-  => MakeLenses xs row row'
+  => MakeLenses Form xs row'
   => Newtype (Form F.FormSpec) (Record row)
   => Record row'
 lenses = mkLensesFromFormSpec formSpec

--- a/src/Internal/Internal.purs
+++ b/src/Internal/Internal.purs
@@ -15,6 +15,8 @@ import Record.Builder (Builder)
 import Record.Builder as Builder
 import Type.Data.RowList (RLProxy(..))
 
+data FormProxy (form :: (Type -> Type -> Type -> Type) -> Type) = FormProxy
+
 -----
 -- Types
 


### PR DESCRIPTION
The `trash` variable was used twice, which caused problems trying to unify `FormSpec` and `InputField` for obvious reasons; just removing the `row` variable fixed that.

The other problem was that the `form` variable was not solved, meaning its constraints could not be resolved. Passing it to the class fixes this.