### PR TITLE
Get inputs

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,7 +17,8 @@
   "dependencies": {
     "purescript-halogen": "^4.0.0",
     "purescript-halogen-renderless": "^0.0.3",
-    "purescript-variant": "^5.0.0"
+    "purescript-variant": "^5.0.0",
+    "purescript-heterogeneous": "^0.1.0"
   },
   "devDependencies": {
     "purescript-halogen-storybook": "^0.4.0",

--- a/src/Formless.purs
+++ b/src/Formless.purs
@@ -55,7 +55,7 @@ import Data.Variant.Internal (VariantRep(..), unsafeGet)
 import Formless.Class.Initial (class Initial, initial)
 import Formless.Internal as Internal
 import Formless.Spec (ErrorType, FormField(..), FormFieldGet, FormFieldLens, FormFieldRow, FormProxy(..), InputField(..), InputType, OutputField(..), OutputType, _Error, _Field, _Input, _Output, _Result, _Touched, _input, _result, _touched, getError, getField, getInput, getOutput, getResult, getTouched)
-import Formless.Spec.Record (getInputs)
+import Formless.Spec.Record (getInputs, getToucheds, getResults)
 import Formless.Spec.Transform (class MakeInputFieldsFromRow, class MakeSProxies, class UnwrapRecord, class WrapRecord, SProxies, makeSProxiesBuilder, mkInputFields, mkInputFieldsFromRowBuilder, mkSProxies, unwrapOutputFields, unwrapRecord, unwrapRecordBuilder, wrapInputFields, wrapRecord, wrapRecordBuilder)
 import Formless.Validation (Validation(..), hoistFn, hoistFnE, hoistFnE_, hoistFnME, hoistFnME_, hoistFn_, runValidation)
 import Halogen as H

--- a/src/Formless.purs
+++ b/src/Formless.purs
@@ -21,6 +21,7 @@ module Formless
   , ValidStatus(..)
   , component
   , module Formless.Spec
+  , module Formless.Spec.Record
   , module Formless.Spec.Transform
   , module Formless.Class.Initial
   , module Formless.Validation
@@ -54,6 +55,7 @@ import Data.Variant.Internal (VariantRep(..), unsafeGet)
 import Formless.Class.Initial (class Initial, initial)
 import Formless.Internal as Internal
 import Formless.Spec (ErrorType, FormField(..), FormFieldGet, FormFieldLens, FormFieldRow, FormProxy(..), InputField(..), InputType, OutputField(..), OutputType, _Error, _Field, _Input, _Output, _Result, _Touched, _input, _result, _touched, getError, getField, getInput, getOutput, getResult, getTouched)
+import Formless.Spec.Record (getInputs)
 import Formless.Spec.Transform (class MakeInputFieldsFromRow, class MakeSProxies, class UnwrapRecord, class WrapRecord, SProxies, makeSProxiesBuilder, mkInputFields, mkInputFieldsFromRowBuilder, mkSProxies, unwrapOutputFields, unwrapRecord, unwrapRecordBuilder, wrapInputFields, wrapRecord, wrapRecordBuilder)
 import Formless.Validation (Validation(..), hoistFn, hoistFnE, hoistFnE_, hoistFnME, hoistFnME_, hoistFn_, runValidation)
 import Halogen as H

--- a/src/Spec/Record.purs
+++ b/src/Spec/Record.purs
@@ -1,4 +1,4 @@
-module Formless.SpecRecord where
+module Formless.Spec.Record where
 
 import Prelude
 

--- a/src/Spec/Record.purs
+++ b/src/Spec/Record.purs
@@ -30,6 +30,17 @@ type FormFieldGetFields sym =
   => form Record FormField 
   -> { | rout }
 
--- | Given a form, get a record containing all the inputs
+fromForm_ :: forall sym. GetProp sym -> FormFieldGetFields sym
+fromForm_ g = hmap g <<< unwrapRecord <<< unwrap
+
+-- | Given a form, get a record of all the fields with their input values 
 getInputs :: FormFieldGetFields "input"
-getInputs = hmap (GetProp (SProxy :: SProxy "input")) <<< unwrapRecord <<< unwrap
+getInputs = fromForm_ (GetProp (SProxy :: SProxy "input"))
+
+-- | Given a form, get a record of all the fields with their touched status
+getToucheds :: FormFieldGetFields "touched"
+getToucheds = fromForm_ (GetProp (SProxy :: SProxy "touched"))
+
+-- | Given a form, get a record of all the fields with their result values
+getResults :: FormFieldGetFields "result"
+getResults = fromForm_ (GetProp (SProxy :: SProxy "result"))

--- a/src/Spec/SpecRecord.purs
+++ b/src/Spec/SpecRecord.purs
@@ -1,0 +1,35 @@
+module Formless.SpecRecord where
+
+import Prelude
+
+import Data.Newtype (class Newtype, unwrap)
+import Formless.Spec (FormField)
+import Formless.Spec.Transform (class UnwrapRecord, unwrapRecord)
+import Heterogeneous.Mapping (class HMap, class MapRecordWithIndex, class Mapping, ConstMapping, hmap)
+import Prim.Row as Row
+import Prim.RowList as RL
+import Record as Record
+import Type.Prelude (class IsSymbol, SProxy(..))
+
+newtype GetProp (prop :: Symbol) = GetProp (SProxy prop)
+
+instance getProp ::
+  (IsSymbol prop, Row.Cons prop a rx r) =>
+  Mapping (GetProp prop) { | r } a where
+  mapping (GetProp prop) = Record.get prop
+
+
+type FormFieldGetFields sym =
+  forall a xs form fields rout ys
+   . Newtype (form Record FormField) { | fields }
+  => RL.RowToList fields xs
+  => UnwrapRecord xs fields a
+  => RL.RowToList a ys
+  => HMap (GetProp sym) { | a } { | rout }
+  => MapRecordWithIndex ys (ConstMapping (GetProp sym)) a rout
+  => form Record FormField 
+  -> { | rout }
+
+-- | Given a form, get a record containing all the inputs
+getInputs :: FormFieldGetFields "input"
+getInputs = hmap (GetProp (SProxy :: SProxy "input")) <<< unwrapRecord <<< unwrap


### PR DESCRIPTION
## What does this pull request do?

Following #19, this pull request adds three utility functions: `getInputs`, `getToucheds` and `getResults`.
These functions extract take a form as input, and return a record with all the fields with the corresponding subfield value.

## Where should the reviewer start?

Most of the code is in `Formless.Spec.Record`

## How should this be manually tested?

The test suite is empty! I manually tested this with my project and it works.

## Other Notes:

The name `Record` is bad and should be changed. I had to put the code in a different file than `Spec` to avoid circular dependencies issues for `UnwrapRecord`.

If you just want to reimplement this all from scratch it's fine ;)
