### PR TITLE
Remove submitter function and type.

### DIFF
--- a/example/App/UI/Element.purs
+++ b/example/App/UI/Element.purs
@@ -156,7 +156,7 @@ textarea config props =
 
 -- Already ready to work with Formless
 formlessField
-  :: ∀ form sym e o t0 t1 m pq cq cs out r fields inputs
+  :: ∀ form sym e o t0 t1 m pq cq cs r fields inputs
    . IsSymbol sym
   => ToText e
   => Newtype (form Record F.FormField) (Record fields)
@@ -166,13 +166,13 @@ formlessField
   => ( FieldConfig'
      -> Array ( HH.IProp
                 ( value :: String, onBlur :: FocusEvent, onInput :: Event | r)
-                ( F.Query pq cq cs form out m Unit )
+                ( F.Query pq cq cs form m Unit )
               )
-     -> F.HTML pq cq cs form out m
+     -> F.HTML pq cq cs form m
      )
   -> FieldConfig sym
-  -> F.State form out m
-  -> F.HTML pq cq cs form out m
+  -> F.State form m
+  -> F.HTML pq cq cs form m
 formlessField fieldType config state = fieldType (Builder.build config' config) props
   where
     config' =

--- a/example/basic/Component.purs
+++ b/example/basic/Component.purs
@@ -16,9 +16,9 @@ import Halogen.HTML as HH
 import Halogen.HTML.Events as HE
 import Halogen.HTML.Properties as HP
 
-data Query a = Formless (F.Message' Form) a
+data Query a = Formless (F.Message' ContactForm) a
 
-type ChildQuery = F.Query' Form Aff
+type ChildQuery = F.Query' ContactForm Aff
 type ChildSlot = Unit
 
 component :: H.Component HH.HTML Query Unit Void Aff
@@ -45,7 +45,7 @@ component = H.parentComponent
 
   eval :: Query ~> H.ParentDSL Unit Query ChildQuery ChildSlot Void Aff
   eval (Formless (F.Submitted formOutputs) a) = a <$ do
-    -- To unwrap the OutputField newtypes on each field and the overall Form newtype,
+    -- To unwrap the OutputField newtypes on each field and the overall ContactForm newtype,
     -- use the unwrapOutputFields helper.
     let contact :: Contact
         contact = F.unwrapOutputFields formOutputs
@@ -60,19 +60,19 @@ component = H.parentComponent
 
 type Contact = { name :: String, text :: String }
 
-newtype Form r f = Form (r
+newtype ContactForm r f = ContactForm (r
   ( name :: f V.FieldError String String
   , text :: f Void String String
   ))
-derive instance newtypeForm :: Newtype (Form r f) _
+derive instance newtypeContactForm :: Newtype (ContactForm r f) _
 
-initialInputs :: Form Record F.InputField
+initialInputs :: ContactForm Record F.InputField
 initialInputs = F.wrapInputFields { name: "", text: "" }
 
-validators :: Form Record (F.Validation Form Aff)
-validators = Form { name: V.minLength 5, text: F.hoistFn_ identity }
+validators :: ContactForm Record (F.Validation ContactForm Aff)
+validators = ContactForm { name: V.minLength 5, text: F.hoistFn_ identity }
 
-renderFormless :: F.State Form Aff -> F.HTML' Form Aff
+renderFormless :: F.State ContactForm Aff -> F.HTML' ContactForm Aff
 renderFormless state =
  UI.formContent_
  [ UI.input

--- a/example/external-components/Component.purs
+++ b/example/external-components/Component.purs
@@ -9,7 +9,7 @@ import Effect.Console as Console
 import Example.App.UI.Element as UI
 import Example.App.UI.Typeahead as TA
 import Example.ExternalComponents.RenderForm (formless)
-import Example.ExternalComponents.Spec (User, prx, inputs, validators, submitter)
+import Example.ExternalComponents.Spec (User, prx, initialInputs, validators)
 import Example.ExternalComponents.Types (ChildQuery, ChildSlot, Query(..), Slot(..), State)
 import Formless as F
 import Halogen as H
@@ -44,23 +44,17 @@ component =
         <> "show you your errors. If you submit a valid form, you'll see Formless just returns the "
         <> "valid outputs for you to work with."
     , HH.br_
-    , HH.slot
-        unit
-        F.component
-        { inputs
-        , validators
-        , submitter
-        , render: formless
-        }
-        (HE.input Formless)
+    , HH.slot unit F.component { initialInputs, validators, render: formless } (HE.input Formless)
     ]
 
   eval :: Query ~> H.ParentDSL State Query ChildQuery ChildSlot Void Aff
   eval = case _ of
     Formless m a -> a <$ case m of
       F.Emit q -> eval q
-      F.Submitted user -> do
-        H.liftEffect $ Console.log $ show (user :: User)
+      F.Submitted formOutputs -> do
+        let user :: User
+            user = F.unwrapOutputFields formOutputs
+        H.liftEffect $ Console.logShow user
       F.Changed fstate -> do
         H.liftEffect $ Console.log $ show $ delete (SProxy :: SProxy "form") fstate
 

--- a/example/external-components/RenderForm.purs
+++ b/example/external-components/RenderForm.purs
@@ -5,7 +5,7 @@ import Prelude
 import Effect.Aff (Aff)
 import Example.App.UI.Element as UI
 import Example.App.UI.Typeahead as TA
-import Example.ExternalComponents.Spec (Form, User, prx)
+import Example.ExternalComponents.Spec (Form, prx)
 import Example.ExternalComponents.Types (Query(..), Slot(..))
 import Formless as F
 import Halogen as H
@@ -13,7 +13,7 @@ import Halogen.HTML as HH
 import Halogen.HTML.Events as HE
 import Halogen.HTML.Properties as HP
 
-formless :: F.State Form User Aff -> F.HTML Query (TA.Query String) Slot Form User Aff
+formless :: F.State Form Aff -> F.HTML Query (TA.Query String) Slot Form Aff
 formless state =
   UI.formContent_
     [ UI.formlessField
@@ -51,7 +51,7 @@ formless state =
 ----------
 -- Helpers
 
-email :: F.State Form User Aff -> F.HTML Query (TA.Query String) Slot Form User Aff
+email :: F.State Form Aff -> F.HTML Query (TA.Query String) Slot Form Aff
 email state =
   UI.field
   { label: "Email"
@@ -70,7 +70,7 @@ email state =
     ( HE.input $ F.Raise <<< H.action <<< Typeahead Email )
   ]
 
-whiskey :: F.State Form User Aff -> F.HTML Query (TA.Query String) Slot Form User Aff
+whiskey :: F.State Form Aff -> F.HTML Query (TA.Query String) Slot Form Aff
 whiskey state =
   UI.field
   { label: "Whiskey"
@@ -88,7 +88,7 @@ whiskey state =
       ( HE.input $ F.Raise <<< H.action <<< Typeahead Whiskey )
   ]
 
-language :: F.State Form User Aff -> F.HTML Query (TA.Query String) Slot Form User Aff
+language :: F.State Form Aff -> F.HTML Query (TA.Query String) Slot Form Aff
 language state =
   UI.field
   { label: "Language"

--- a/example/external-components/RenderForm.purs
+++ b/example/external-components/RenderForm.purs
@@ -5,7 +5,7 @@ import Prelude
 import Effect.Aff (Aff)
 import Example.App.UI.Element as UI
 import Example.App.UI.Typeahead as TA
-import Example.ExternalComponents.Spec (Form, prx)
+import Example.ExternalComponents.Spec (UserForm, prx)
 import Example.ExternalComponents.Types (Query(..), Slot(..))
 import Formless as F
 import Halogen as H
@@ -13,7 +13,7 @@ import Halogen.HTML as HH
 import Halogen.HTML.Events as HE
 import Halogen.HTML.Properties as HP
 
-formless :: F.State Form Aff -> F.HTML Query (TA.Query String) Slot Form Aff
+formless :: F.State UserForm Aff -> F.HTML Query (TA.Query String) Slot UserForm Aff
 formless state =
   UI.formContent_
     [ UI.formlessField
@@ -51,7 +51,7 @@ formless state =
 ----------
 -- Helpers
 
-email :: F.State Form Aff -> F.HTML Query (TA.Query String) Slot Form Aff
+email :: F.State UserForm Aff -> F.HTML Query (TA.Query String) Slot UserForm Aff
 email state =
   UI.field
   { label: "Email"
@@ -70,7 +70,7 @@ email state =
     ( HE.input $ F.Raise <<< H.action <<< Typeahead Email )
   ]
 
-whiskey :: F.State Form Aff -> F.HTML Query (TA.Query String) Slot Form Aff
+whiskey :: F.State UserForm Aff -> F.HTML Query (TA.Query String) Slot UserForm Aff
 whiskey state =
   UI.field
   { label: "Whiskey"
@@ -88,7 +88,7 @@ whiskey state =
       ( HE.input $ F.Raise <<< H.action <<< Typeahead Whiskey )
   ]
 
-language :: F.State Form Aff -> F.HTML Query (TA.Query String) Slot Form Aff
+language :: F.State UserForm Aff -> F.HTML Query (TA.Query String) Slot UserForm Aff
 language state =
   UI.field
   { label: "Language"

--- a/example/external-components/Spec.purs
+++ b/example/external-components/Spec.purs
@@ -8,6 +8,8 @@ import Effect.Class (class MonadEffect)
 import Example.App.Validation as V
 import Formless as F
 
+-- We can easily reclaim our ideal User type by picking the
+-- parsed outputs from the FormRow like this:
 type User = Record (FormRow F.OutputType)
 
 newtype Form r f = Form (r (FormRow f))
@@ -24,8 +26,9 @@ type FormRow f =
 prx :: F.SProxies Form
 prx = F.mkSProxies $ F.FormProxy :: F.FormProxy Form
 
-inputs :: Form Record F.InputField
-inputs = F.mkInputFields $ F.FormProxy :: F.FormProxy Form
+-- | You can generate your initial inputs
+initialInputs :: Form Record F.InputField
+initialInputs = F.mkInputFields $ F.FormProxy :: F.FormProxy Form
 
 validators :: ∀ m. MonadEffect m => Form Record (F.Validation Form m)
 validators = Form
@@ -36,6 +39,3 @@ validators = Form
   , whiskey: V.exists
   , language: V.exists
   }
-
-submitter :: ∀ m. Monad m => Form Record F.OutputField -> m User
-submitter = pure <<< F.unwrapOutputFields

--- a/example/external-components/Spec.purs
+++ b/example/external-components/Spec.purs
@@ -10,12 +10,12 @@ import Formless as F
 
 -- We can easily reclaim our ideal User type by picking the
 -- parsed outputs from the FormRow like this:
-type User = Record (FormRow F.OutputType)
+type User = Record (UserFormRow F.OutputType)
 
-newtype Form r f = Form (r (FormRow f))
-derive instance newtypeForm' :: Newtype (Form r f) _
+newtype UserForm r f = UserForm (r (UserFormRow f))
+derive instance newtypeUserForm' :: Newtype (UserForm r f) _
 
-type FormRow f =
+type UserFormRow f =
   ( name     :: f V.FieldError String         String
   , email    :: f V.FieldError (Maybe String) V.Email
   , whiskey  :: f V.FieldError (Maybe String) String
@@ -23,15 +23,15 @@ type FormRow f =
   )
 
 -- | You'll usually want symbol proxies for convenience
-prx :: F.SProxies Form
-prx = F.mkSProxies $ F.FormProxy :: F.FormProxy Form
+prx :: F.SProxies UserForm
+prx = F.mkSProxies $ F.FormProxy :: F.FormProxy UserForm
 
 -- | You can generate your initial inputs
-initialInputs :: Form Record F.InputField
-initialInputs = F.mkInputFields $ F.FormProxy :: F.FormProxy Form
+initialInputs :: UserForm Record F.InputField
+initialInputs = F.mkInputFields $ F.FormProxy :: F.FormProxy UserForm
 
-validators :: ∀ m. MonadEffect m => Form Record (F.Validation Form m)
-validators = Form
+validators :: ∀ m. MonadEffect m => UserForm Record (F.Validation UserForm m)
+validators = UserForm
   { name: V.minLength 7
     -- Unpacks the Maybe value, then checks the email format, then verifies it is not in use
     -- monadically.

--- a/example/external-components/Types.purs
+++ b/example/external-components/Types.purs
@@ -5,20 +5,20 @@ import Prelude
 import Data.Maybe (Maybe)
 import Effect.Aff (Aff)
 import Example.App.UI.Typeahead as TA
-import Example.ExternalComponents.Spec (Form, User)
+import Example.ExternalComponents.Spec (Form)
 import Formless as F
 
 ----------
 -- Component
 
 data Query a
-  = Formless (F.Message Query Form User) a
+  = Formless (F.Message Query Form) a
   | Typeahead Slot (TA.Message Maybe String) a
   | Reset a
 
 type State = Unit
 
-type ChildQuery = F.Query Query (TA.Query String) Slot Form User Aff
+type ChildQuery = F.Query Query (TA.Query String) Slot Form Aff
 type ChildSlot = Unit
 
 data Slot

--- a/example/external-components/Types.purs
+++ b/example/external-components/Types.purs
@@ -5,20 +5,20 @@ import Prelude
 import Data.Maybe (Maybe)
 import Effect.Aff (Aff)
 import Example.App.UI.Typeahead as TA
-import Example.ExternalComponents.Spec (Form)
+import Example.ExternalComponents.Spec (UserForm)
 import Formless as F
 
 ----------
 -- Component
 
 data Query a
-  = Formless (F.Message Query Form) a
+  = Formless (F.Message Query UserForm) a
   | Typeahead Slot (TA.Message Maybe String) a
   | Reset a
 
 type State = Unit
 
-type ChildQuery = F.Query Query (TA.Query String) Slot Form Aff
+type ChildQuery = F.Query Query (TA.Query String) Slot UserForm Aff
 type ChildSlot = Unit
 
 data Slot

--- a/example/real-world/Render/GroupForm.purs
+++ b/example/real-world/Render/GroupForm.purs
@@ -18,12 +18,10 @@ import Halogen.HTML.Events as HE
 import Halogen.HTML.Properties (value) as HP
 
 -- | A convenience synonym for the group Formless state
-type FormlessState
-  = F.State G.GroupForm G.Group Aff
+type FormlessState = F.State G.GroupForm Aff
 
 -- | A convenience synonym for the group Formless HTML type
-type FormlessHTML
-  = F.HTML Query GroupCQ GroupCS G.GroupForm G.Group Aff
+type FormlessHTML = F.HTML Query GroupCQ GroupCS G.GroupForm Aff
 
 -- | The form, grouped by sections.
 render :: FormlessState -> FormlessHTML

--- a/example/real-world/Render/OptionsForm.purs
+++ b/example/real-world/Render/OptionsForm.purs
@@ -12,7 +12,7 @@ import Example.App.UI.Element (css)
 import Example.App.UI.Element as UI
 import Example.RealWorld.Data.Options (Metric(..), Speed(..), prx)
 import Example.RealWorld.Data.Options as OP
-import Example.RealWorld.Types (OptionsCQ, OptionsCS, Query(..))
+import Example.RealWorld.Types (Query(..))
 import Formless as F
 import Halogen as H
 import Halogen.HTML as HH
@@ -20,12 +20,10 @@ import Halogen.HTML.Events as HE
 import Halogen.HTML.Properties as HP
 
 -- | A convenience synonym for the group Formless state
-type FormlessState
-  = F.State OP.OptionsForm OP.Options Aff
+type FormlessState = F.State OP.OptionsForm Aff
 
 -- | A convenience synonym for the group Formless HTML type
-type FormlessHTML
-  = F.HTML Query OptionsCQ OptionsCS OP.OptionsForm OP.Options Aff
+type FormlessHTML = F.HTML Query (Dropdown.Query Metric) Unit OP.OptionsForm Aff
 
 -- | The form, grouped by sections.
 render :: FormlessState -> FormlessHTML
@@ -34,9 +32,7 @@ render state =
     [ renderEnabled state
     , HH.div
       [ if F.getInput prx.enable state.form then css "" else css "is-hidden" ]
-      ( renderMetrics state
-      <> renderOthers state
-      )
+      ( renderMetrics state <> renderOthers state )
     ]
 
 -----

--- a/example/real-world/Types.purs
+++ b/example/real-world/Types.purs
@@ -9,7 +9,7 @@ import Effect.Aff (Aff)
 import Example.App.UI.Dropdown as Dropdown
 import Example.App.UI.Typeahead as TA
 import Example.RealWorld.Data.Group (Admin, Group, GroupForm)
-import Example.RealWorld.Data.Options (Metric, Options, OptionsForm)
+import Example.RealWorld.Data.Options (Metric, OptionsForm)
 import Formless as Formless
 
 ----------
@@ -18,8 +18,8 @@ import Formless as Formless
 -- | This component will only handle output from Formless to keep
 -- | things simple.
 data Query a
-  = GroupForm (Formless.Message Query GroupForm Group) a
-  | OptionsForm (Formless.Message Query OptionsForm Options) a
+  = GroupForm (Formless.Message Query GroupForm) a
+  | OptionsForm (Formless.Message Query OptionsForm) a
   | TASingle (TA.Message Maybe String) a
   | TAMulti GroupTASlot (TA.Message Array String) a
   | AdminDropdown (Dropdown.Message Admin) a
@@ -43,45 +43,28 @@ type State =
 
 -- | Now we can create _this_ component's child query and child slot pairing.
 type ChildQuery = Coproduct2
-  (Formless.Query Query GroupCQ GroupCS GroupForm Group Aff)
-  (Formless.Query Query OptionsCQ OptionsCS OptionsForm Options Aff)
+  (Formless.Query Query GroupCQ GroupCS GroupForm Aff)
+  (Formless.Query Query (Dropdown.Query Metric) Unit OptionsForm Aff)
 
-type ChildSlot = Either2
-  Unit
-  Unit
+type ChildSlot = Either2 Unit Unit
 
 ----------
 -- Formless
 
 -- | Types for the group form
-type GroupCQ = Coproduct3
-  (TA.Query String)
-  (TA.Query String)
-  (Dropdown.Query Admin)
-
-type GroupCS = Either3
-  GroupTASlot
-  Unit
-  Unit
-
--- | Types for the options form
-type OptionsCQ = Dropdown.Query Metric
-type OptionsCS = Unit
+type GroupCQ = Coproduct3 (TA.Query String) (TA.Query String) (Dropdown.Query Admin)
+type GroupCS = Either3 GroupTASlot Unit Unit
 
 ----------
 -- Slots
 
-data GroupTASlot
-  = Applications
-  | Pixels
+data GroupTASlot = Applications | Pixels
 derive instance eqGroupTASlot :: Eq GroupTASlot
 derive instance ordGroupTASlot :: Ord GroupTASlot
 
 ----------
 -- Navigation
 
-data Tab
-  = GroupTab
-  | OptionsTab
+data Tab = GroupTab | OptionsTab
 derive instance eqTab :: Eq Tab
 derive instance ordTab :: Ord Tab

--- a/src/Formless.purs
+++ b/src/Formless.purs
@@ -48,7 +48,7 @@ import Data.Maybe (Maybe(..))
 import Data.Monoid.Additive (Additive)
 import Data.Newtype (class Newtype, over, unwrap, wrap)
 import Data.Symbol (class IsSymbol, SProxy(..))
-import Data.Traversable (traverse, traverse_)
+import Data.Traversable (traverse_)
 import Data.Variant (Variant, inj)
 import Data.Variant.Internal (VariantRep(..), unsafeGet)
 import Formless.Class.Initial (class Initial, initial)
@@ -66,7 +66,7 @@ import Record as Record
 import Renderless.State (getState, modifyState, modifyState_, modifyStore_)
 import Unsafe.Coerce (unsafeCoerce)
 
-data Query pq cq cs form out m a
+data Query pq cq cs form m a
   = Modify (form Variant InputField) a
   | Validate (form Variant Internal.U) a
   | ModifyValidate (form Variant InputField) a
@@ -74,45 +74,45 @@ data Query pq cq cs form out m a
   | ResetAll a
   | ValidateAll a
   | Submit a
-  | SubmitReply (Maybe out -> a)
-  | Reply (PublicState form -> a)
+  | SubmitReply (Maybe (form Record OutputField) -> a)
+  | GetState (PublicState form -> a)
   | Send cs (cq Unit) a
   | SyncFormData a
   | Raise (pq Unit) a
   | ReplaceInputs (form Record InputField) a
-  | Receive (Input pq cq cs form out m) a
-  | AndThen (Query pq cq cs form out m Unit) (Query pq cq cs form out m Unit) a
+  | Receive (Input pq cq cs form m) a
+  | AndThen (Query pq cq cs form m Unit) (Query pq cq cs form m Unit) a
 
 -- | The overall component state type, which contains the local state type
 -- | and also the render function
-type StateStore pq cq cs form out m =
-  Store (State form out m) (HTML pq cq cs form out m)
+type StateStore pq cq cs form m =
+  Store (State form m) (HTML pq cq cs form m)
 
 -- | The component type
-type Component pq cq cs form out m
+type Component pq cq cs form m
   = H.Component
       HH.HTML
-      (Query pq cq cs form out m)
-      (Input pq cq cs form out m)
-      (Message pq form out)
+      (Query pq cq cs form m)
+      (Input pq cq cs form m)
+      (Message pq form)
       m
 
 -- | The component's HTML type, the result of the render function.
-type HTML pq cq cs form out m
-  = H.ParentHTML (Query pq cq cs form out m) cq cs m
+type HTML pq cq cs form m
+  = H.ParentHTML (Query pq cq cs form m) cq cs m
 
 -- | The component's DSL type, the result of the eval function.
-type DSL pq cq cs form out m
+type DSL pq cq cs form m
   = H.ParentDSL
-      (StateStore pq cq cs form out m)
-      (Query pq cq cs form out m)
+      (StateStore pq cq cs form m)
+      (Query pq cq cs form m)
       cq
       cs
-      (Message pq form out)
+      (Message pq form)
       m
 
 -- | The component local state
-type State form out m = Record (StateRow form (internal :: InternalState form out m))
+type State form m = Record (StateRow form (internal :: InternalState form m))
 
 -- | The component's public state
 type PublicState form = Record (StateRow form ())
@@ -130,14 +130,12 @@ type StateRow form r =
 
 -- | A newtype to make easier type errors for end users to
 -- | read by hiding internal fields
-newtype InternalState form out m = InternalState
+newtype InternalState form m = InternalState
   { initialInputs :: form Record InputField
-  , formResult :: Maybe out
-  , allTouched :: Boolean
-  , submitter :: form Record OutputField -> m out
   , validators :: form Record (Validation form m)
+  , allTouched :: Boolean
   }
-derive instance newtypeInternalState :: Newtype (InternalState form out m) _
+derive instance newtypeInternalState :: Newtype (InternalState form m) _
 
 -- | A type to represent validation status
 data ValidStatus
@@ -151,50 +149,48 @@ instance showValidStatus :: Show ValidStatus where
   show = genericShow
 
 -- | The component's input type
-type Input pq cq cs form out m =
-  { submitter :: form Record OutputField -> m out
-  , inputs :: form Record InputField
+type Input pq cq cs form m =
+  { initialInputs :: form Record InputField
   , validators :: form Record (Validation form m)
-  , render :: State form out m -> HTML pq cq cs form out m
+  , render :: State form m -> HTML pq cq cs form m
   }
 
 -- | The component tries to require as few messages to be handled as possible. You
 -- | can always use the *Reply variants of queries to perform actions and receive
 -- | a result out the other end.
-data Message pq form out
-  = Submitted out
+data Message pq form
+  = Submitted (form Record OutputField)
   | Changed (PublicState form)
   | Emit (pq Unit)
 
 -- | When you are using several different types of child components in Formless
 -- | the component needs a child path to be able to pick the right slot to send
 -- | a query to.
-send' :: ∀ pq cq' cs' cs cq form out m a
+send' :: ∀ pq cq' cs' cs cq form m a
   . ChildPath cq cq' cs cs'
  -> cs
  -> cq Unit
  -> a
- -> Query pq cq' cs' form out m a
+ -> Query pq cq' cs' form m a
 send' path p q = Send (injSlot path p) (injQuery path q)
 
 -- | Simple types
 
 -- | A simple query type when you have no child slots in use
-type Query' form out m = Query (Const Void) (Const Void) Void form out m
+type Query' form m = Query (Const Void) (Const Void) Void form m
 
 -- | A simple HTML type when the component does not need embedding
-type HTML' form out m = H.ParentHTML (Query' form out m) (Const Void) Void m
+type HTML' form m = H.ParentHTML (Query' form m) (Const Void) Void m
 
 -- | A simple Message type when the component does not need embedding
-type Message' form out = Message (Const Void) form out
+type Message' form = Message (Const Void) form
 
 -- | A simple Input type when the component does not need embedding
-type Input' form out m = Input (Const Void) (Const Void) Void form out m
-
+type Input' form m = Input (Const Void) (Const Void) Void form m
 
 -- | The component itself
 component
-  :: ∀ pq cq cs form out m fieldxs fields countxs count inputsxs inputs vs outputs us uxs
+  :: ∀ pq cq cs form m fieldxs fields countxs count inputsxs inputs vs us uxs outputs
    . Ord cs
   => Monad m
   => RL.RowToList fields fieldxs
@@ -205,7 +201,6 @@ component
   => Internal.InputFieldsToFormFields inputsxs inputs fields
   => Internal.FormFieldsToInputFields fieldxs fields inputs
   => Internal.TransformFormFields fieldxs fields fields
-  => Internal.FormFieldToMaybeOutput fieldxs fields outputs
   => Internal.CountErrors fieldxs fields count
   => Internal.AllTouched fieldxs fields
   => Internal.SumRecord countxs count (Additive Int)
@@ -213,14 +208,15 @@ component
   => Internal.ApplyValidation vs fieldxs fields fields m
   => Internal.SetInputVariantRL inputsxs inputs fields
   => Internal.ValidateVariantRL uxs us fields m
+  => Internal.FormFieldToMaybeOutput fieldxs fields outputs
   => Newtype (form Record InputField) (Record inputs)
   => Newtype (form Variant InputField) (Variant inputs)
   => Newtype (form Record FormField) (Record fields)
   => Newtype (form Record (Validation form m)) (Record vs)
   => Newtype (form Variant (Validation form m)) (Variant vs)
-  => Newtype (form Record OutputField) (Record outputs)
   => Newtype (form Variant Internal.U) (Variant us)
-  => Component pq cq cs form out m
+  => Newtype (form Record OutputField) (Record outputs)
+  => Component pq cq cs form m
 component =
   H.parentComponent
     { initialState
@@ -230,24 +226,18 @@ component =
     }
   where
 
-  initialState :: Input pq cq cs form out m -> StateStore pq cq cs form out m
-  initialState { inputs, validators, render, submitter } = store render $
+  initialState :: Input pq cq cs form m -> StateStore pq cq cs form m
+  initialState { initialInputs, validators, render } = store render $
     { validity: Incomplete
     , dirty: false
     , errors: 0
     , submitAttempts: 0
     , submitting: false
-    , form: Internal.inputFieldsToFormFields inputs
-    , internal: InternalState
-      { formResult: Nothing
-      , allTouched: false
-      , initialInputs: inputs
-      , submitter
-      , validators
-      }
+    , form: Internal.inputFieldsToFormFields initialInputs
+    , internal: InternalState { allTouched: false, initialInputs, validators }
     }
 
-  eval :: Query pq cq cs form out m ~> DSL pq cq cs form out m
+  eval :: Query pq cq cs form m ~> DSL pq cq cs form m
   eval = case _ of
     Modify variant a -> do
       modifyWithInputVariant variant
@@ -308,14 +298,15 @@ component =
       pure a
 
     -- Submit, also raising a message to the user
-    Submit a -> a <$ do
-      st <- runSubmit
-      traverse_ (H.raise <<< Submitted) st
+    Submit a -> do
+      mbForm <- runSubmit
+      traverse_ (H.raise <<< Submitted) mbForm
+      pure a
 
-    -- Submit, without raising a message, but returning the result directly
+    -- Submit, not raising a message
     SubmitReply reply -> do
-       st <- runSubmit
-       pure $ reply st
+      mbForm <- runSubmit
+      pure $ reply mbForm
 
     -- | Should completely reset the form to its initial state
     ResetAll a -> do
@@ -325,16 +316,12 @@ component =
         , errors = 0
         , submitAttempts = 0
         , form = Internal.replaceFormFieldInputs (unwrap st.internal).initialInputs st.form
-        , internal = over InternalState (_
-            { formResult = Nothing
-            , allTouched = false
-            }
-          ) st.internal
+        , internal = over InternalState (_ { allTouched = false }) st.internal
         }
       H.raise $ Changed $ getPublicState new
       pure a
 
-    Reply reply -> do
+    GetState reply -> do
       st <- getState
       pure $ reply $ getPublicState st
 
@@ -355,17 +342,13 @@ component =
         , submitAttempts = 0
         , submitting = false
         , form = Internal.replaceFormFieldInputs formInputs st.form
-        , internal = over InternalState
-          (_ { formResult = Nothing
-             , allTouched = false
-             , initialInputs = formInputs
-             }) st.internal
+        , internal = over InternalState (_ { allTouched = false, initialInputs = formInputs }) st.internal
         }
       H.raise $ Changed $ getPublicState new
       pure a
 
-    Receive { render, validators, submitter } a -> do
-      let applyOver = over InternalState (_ { validators = validators, submitter = submitter })
+    Receive { render, validators } a -> do
+      let applyOver = over InternalState (_ { validators = validators })
       modifyStore_ render (\st -> st { internal = applyOver st.internal })
       pure a
 
@@ -375,11 +358,11 @@ component =
       pure a
 
   -- Remove internal fields and return the public state
-  getPublicState :: State form out m -> PublicState form
+  getPublicState :: State form m -> PublicState form
   getPublicState = Record.delete (SProxy :: SProxy "internal")
 
   -- Use a form variant to update the value of a single form field in state
-  modifyWithInputVariant :: form Variant InputField -> DSL pq cq cs form out m Unit
+  modifyWithInputVariant :: form Variant InputField -> DSL pq cq cs form m Unit
   modifyWithInputVariant variant = do
     modifyState_ \st -> st { form = wrap $ updater $ unwrap st.form }
     where
@@ -389,7 +372,7 @@ component =
 
   -- Use a form variant to update the value of a single form field in state
   -- and also run its validation
-  validateWithUVariant :: form Variant Internal.U -> DSL pq cq cs form out m Unit
+  validateWithUVariant :: form Variant Internal.U -> DSL pq cq cs form m Unit
   validateWithUVariant variant = do
     st <- getState
     form <- H.lift $ updater st
@@ -398,7 +381,7 @@ component =
       variantRep :: ∀ i. VariantRep i
       variantRep = unsafeCoerce variant
 
-      validator :: ∀ e i o. State form out m -> VariantRep i -> Validation form m e i o
+      validator :: ∀ e i o. State form m -> VariantRep i -> Validation form m e i o
       validator state (VariantRep { type: t }) = unsafeGet t (unwrap (unwrap state.internal).validators)
 
       updater state = Internal.validateVariant
@@ -414,7 +397,7 @@ component =
         (unwrap state.form)
 
   -- Validate a field without modifying its input
-  modifyValidateWithInputVariant :: form Variant InputField -> DSL pq cq cs form out m Unit
+  modifyValidateWithInputVariant :: form Variant InputField -> DSL pq cq cs form m Unit
   modifyValidateWithInputVariant variant = do
     st <- modifyState \st -> st { form = wrap $ inputUpdater $ unwrap st.form }
     form <- H.lift $ validateUpdater st
@@ -424,7 +407,7 @@ component =
       variantRep :: ∀ i. VariantRep i
       variantRep = unsafeCoerce variant
 
-      validator :: ∀ e i o. State form out m -> VariantRep i -> Validation form m e i o
+      validator :: ∀ e i o. State form m -> VariantRep i -> Validation form m e i o
       validator state (VariantRep { type: t }) = unsafeGet t (unwrap (unwrap state.internal).validators)
 
       validateUpdater state = Internal.validateVariant
@@ -447,7 +430,7 @@ component =
 
   -- Reset a field (and update state to ensure the form is not marked with
   -- all fields touched).
-  resetWithInputVariant :: form Variant InputField -> DSL pq cq cs form out m Unit
+  resetWithInputVariant :: form Variant InputField -> DSL pq cq cs form m Unit
   resetWithInputVariant variant =
     modifyState_ \st ->
       st { form = wrap $ updater $ unwrap st.form
@@ -459,7 +442,7 @@ component =
         (unwrap variant)
 
   -- Run submission without raising messages or replies
-  runSubmit :: DSL pq cq cs form out m (Maybe out)
+  runSubmit :: DSL pq cq cs form m (Maybe (form Record OutputField))
   runSubmit = do
     init <- modifyState \st -> st
       { submitAttempts = st.submitAttempts + 1
@@ -479,16 +462,13 @@ component =
 
     -- For performance purposes, only attempt to submit if the form is valid
     validated <- getState
-    when (validated.validity == Valid) do
-      output <- H.lift $
-        traverse internal.submitter (Internal.inputFieldToMaybeOutput validated.form)
-      modifyState_ _
-        { internal = over InternalState (_ { formResult = output }) validated.internal }
 
-    -- Ensure the form is no longer marked submitting
-    result <- modifyState \st -> st { submitting = false }
-    pure (unwrap result.internal).formResult
-
+    case validated.validity of
+      Valid -> do
+        -- Ensure the form is no longer marked submitting
+        result <- modifyState \st -> st { submitting = false }
+        pure $ Internal.formFieldsToMaybeOutput validated.form
+      _ -> pure Nothing
 
 ----------
 -- Component helper functions for variants
@@ -496,96 +476,96 @@ component =
 -- | A helper to create the correct `Modify` query for Formless given a label and
 -- | an input value
 modify
-  :: ∀ pq cq cs form inputs out m sym t0 e i o a
+  :: ∀ pq cq cs form inputs m sym t0 e i o a
    . IsSymbol sym
   => Newtype (form Variant InputField) (Variant inputs)
   => Row.Cons sym (InputField e i o) t0 inputs
   => SProxy sym
   -> i
   -> a
-  -> Query pq cq cs form out m a
+  -> Query pq cq cs form m a
 modify sym i = Modify (wrap (inj sym (wrap i)))
 
 -- | A helper to create the correct `Modify` query for Formless given a label and
 -- | an input value, as an action
 modify_
-  :: ∀ pq cq cs form inputs out m sym t0 e i o
+  :: ∀ pq cq cs form inputs m sym t0 e i o
    . IsSymbol sym
   => Newtype (form Variant InputField) (Variant inputs)
   => Row.Cons sym (InputField e i o) t0 inputs
   => SProxy sym
   -> i
-  -> Query pq cq cs form out m Unit
+  -> Query pq cq cs form m Unit
 modify_ sym i = Modify (wrap (inj sym (wrap i))) unit
 
 -- | A helper to create the correct `ModifyValidate` query for Formless given a
 -- | label and an input value
 modifyValidate
-  :: ∀ pq cq cs form inputs out m sym t0 e i o a
+  :: ∀ pq cq cs form inputs m sym t0 e i o a
    . IsSymbol sym
   => Newtype (form Variant InputField) (Variant inputs)
   => Row.Cons sym (InputField e i o) t0 inputs
   => SProxy sym
   -> i
   -> a
-  -> Query pq cq cs form out m a
+  -> Query pq cq cs form m a
 modifyValidate sym i = ModifyValidate (wrap (inj sym (wrap i)))
 
 -- | A helper to create the correct `ModifyValidate` query for Formless given a
 -- | label and an input value, as an action
 modifyValidate_
-  :: ∀ pq cq cs form inputs out m sym t0 e i o
+  :: ∀ pq cq cs form inputs m sym t0 e i o
    . IsSymbol sym
   => Newtype (form Variant InputField) (Variant inputs)
   => Row.Cons sym (InputField e i o) t0 inputs
   => SProxy sym
   -> i
-  -> Query pq cq cs form out m Unit
+  -> Query pq cq cs form m Unit
 modifyValidate_ sym i = ModifyValidate (wrap (inj sym (wrap i))) unit
 
 -- | A helper to create the correct `Reset` query for Formless given a label
 reset
-  :: ∀ pq cq cs form inputs out m sym a t0 e i o
+  :: ∀ pq cq cs form inputs m sym a t0 e i o
    . IsSymbol sym
   => Initial i
   => Newtype (form Variant InputField) (Variant inputs)
   => Row.Cons sym (InputField e i o) t0 inputs
   => SProxy sym
   -> a
-  -> Query pq cq cs form out m a
+  -> Query pq cq cs form m a
 reset sym = Reset (wrap (inj sym (wrap initial)))
 
 -- | A helper to create the correct `Reset` query for Formless given a label,
 -- | as an action.
 reset_
-  :: ∀ pq cq cs form inputs out m sym t0 e i o
+  :: ∀ pq cq cs form inputs m sym t0 e i o
    . IsSymbol sym
   => Initial i
   => Newtype (form Variant InputField) (Variant inputs)
   => Row.Cons sym (InputField e i o) t0 inputs
   => SProxy sym
-  -> Query pq cq cs form out m Unit
+  -> Query pq cq cs form m Unit
 reset_ sym = Reset (wrap (inj sym (wrap initial))) unit
 
 -- | A helper to create the correct `Validate` query for Formless, given
 -- | a label
 validate
-  :: ∀ pq cq cs form us out m sym a t0 e i o
+  :: ∀ pq cq cs form us m sym a t0 e i o
    . IsSymbol sym
   => Newtype (form Variant Internal.U) (Variant us)
   => Row.Cons sym (Internal.U e i o) t0 us
   => SProxy sym
   -> a
-  -> Query pq cq cs form out m a
+  -> Query pq cq cs form m a
 validate sym = Validate (wrap (inj sym Internal.U))
 
 -- | A helper to create the correct `Validate` query for Formless given
 -- | a label, as an action
 validate_
-  :: ∀ pq cq cs form us out m sym t0 e i o
+  :: ∀ pq cq cs form us m sym t0 e i o
    . IsSymbol sym
   => Newtype (form Variant Internal.U) (Variant us)
   => Row.Cons sym (Internal.U e i o) t0 us
   => SProxy sym
-  -> Query pq cq cs form out m Unit
+  -> Query pq cq cs form m Unit
 validate_ sym = Validate (wrap (inj sym Internal.U)) unit


### PR DESCRIPTION
## What does this pull request do?

Removes the `submitter` function and `out` type from the component for simplicity. For further details:

Resolves https://github.com/thomashoneyman/purescript-halogen-formless/issues/21

## Where should the reviewer start?

Review changes to the Formless component and to how the `Submitted` message is handled in each example file.

## Other Notes:

I'll leave this PR open until tomorrow for comments.

