### PR TITLE
Add optional validation via heterogenous (by @dariooddenino)

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,7 +17,8 @@
   "dependencies": {
     "purescript-halogen": "^4.0.0",
     "purescript-halogen-renderless": "^0.0.3",
-    "purescript-variant": "^5.0.0"
+    "purescript-variant": "^5.0.0",
+    "purescript-heterogeneous": "^0.1.0"
   },
   "devDependencies": {
     "purescript-halogen-storybook": "^0.4.0",


### PR DESCRIPTION
## What does this pull request do?

Allows users to easily provide a no validation case by generating `hoistFn_ identity` for every field in their row. An alternative to making validation entirely optional with `Maybe` which is incompatible with allowing, in all other constraints, the possibility that an input and output are not the same.

Credit to @dariooddenino (If you would like to create your own PR with this code, feel free, and I will merge yours instead).

Resolves https://github.com/thomashoneyman/purescript-halogen-formless/issues/20

## Other Notes

This brings in the `purescript-heterogeneous` library as a dependency. This is in anticipation of a larger overhaul replacing various row-to-list boilerplate instances with purescript-heterogeneous.