### PR TITLE
Add support for requests

### DIFF
--- a/example/App/UI/Typeahead.purs
+++ b/example/App/UI/Typeahead.purs
@@ -18,6 +18,7 @@ import Select.Utils.Setters as Setters
 
 data Query item a
   = HandleSelect (Select.Message (Query item) item) a
+  | GetItems (Array item -> a)
   | Remove item a
   | Clear a
 
@@ -160,6 +161,10 @@ component' select' remove' filter' render' =
       _ <- H.query unit $ Select.replaceItems $ filter' st.items st.selected
       H.raise (SelectionsChanged st.selected)
       pure next
+
+    GetItems f -> do
+      st <- H.get
+      pure $ f st.items
 
     HandleSelect message next -> case message of
       Select.Emit q -> eval q $> next

--- a/example/real-world/Component.purs
+++ b/example/real-world/Component.purs
@@ -115,12 +115,12 @@ component =
 
     Reset a -> do
       -- To send a query through to a child component when Formless has multiple, use send'
-      _ <- H.query' CP.cp1 unit $ H.action $ F.send' CP.cp1 Applications (H.action TA.Clear)
-      _ <- H.query' CP.cp1 unit $ H.action $ F.send' CP.cp1 Pixels (H.action TA.Clear)
-      _ <- H.query' CP.cp1 unit $ H.action $ F.send' CP.cp2 unit (H.action TA.Clear)
-      _ <- H.query' CP.cp1 unit $ H.action $ F.send' CP.cp3 unit (H.action DD.Clear)
+      _ <- H.query' CP.cp1 unit $ F.send' CP.cp1 Applications (H.action TA.Clear)
+      _ <- H.query' CP.cp1 unit $ F.send' CP.cp1 Pixels (H.action TA.Clear)
+      _ <- H.query' CP.cp1 unit $ F.send' CP.cp2 unit (H.action TA.Clear)
+      _ <- H.query' CP.cp1 unit $ F.send' CP.cp3 unit (H.action DD.Clear)
       -- If there is only one child type, use Send
-      _ <- H.query' CP.cp2 unit $ H.action $ F.Send unit (H.action DD.Clear)
+      _ <- H.query' CP.cp2 unit $ F.send unit (H.action DD.Clear)
       _ <- H.query' CP.cp1 unit $ H.action F.ResetAll
       _ <- H.query' CP.cp2 unit $ H.action F.ResetAll
       pure a

--- a/src/Formless.purs
+++ b/src/Formless.purs
@@ -24,6 +24,7 @@ module Formless
   , module Formless.Spec.Transform
   , module Formless.Class.Initial
   , module Formless.Validation
+  , send
   , send'
   , modify
   , modify_
@@ -40,7 +41,9 @@ import Prelude
 
 import Control.Comonad (extract)
 import Control.Comonad.Store (Store, store)
+import Control.Monad.Free (liftF)
 import Data.Const (Const)
+import Data.Coyoneda (coyoneda)
 import Data.Eq (class EqRecord)
 import Data.Generic.Rep (class Generic)
 import Data.Generic.Rep.Show (genericShow)
@@ -76,7 +79,7 @@ data Query pq cq cs form m a
   | Submit a
   | SubmitReply (Maybe (form Record OutputField) -> a)
   | GetState (PublicState form -> a)
-  | Send cs (cq Unit) a
+  | Send cs (cq a)
   | SyncFormData a
   | Raise (pq Unit) a
   | ReplaceInputs (form Record InputField) a
@@ -162,17 +165,6 @@ data Message pq form
   = Submitted (form Record OutputField)
   | Changed (PublicState form)
   | Emit (pq Unit)
-
--- | When you are using several different types of child components in Formless
--- | the component needs a child path to be able to pick the right slot to send
--- | a query to.
-send' :: ∀ pq cq' cs' cs cq form m a
-  . ChildPath cq cq' cs cs'
- -> cs
- -> cq Unit
- -> a
- -> Query pq cq' cs' form m a
-send' path p q = Send (injSlot path p) (injQuery path q)
 
 -- | Simple types
 
@@ -325,9 +317,7 @@ component =
       st <- getState
       pure $ reply $ getPublicState st
 
-    -- Only allows actions; always returns nothing. In Halogen v5.0.0 branch this does return
-    -- requests as expected in a Halogen component.
-    Send cs cq a -> H.query cs cq $> a
+    Send cs cq -> H.HalogenM $ liftF $ H.ChildQuery cs $ coyoneda identity cq
 
     Raise query a -> do
       H.raise (Emit query)
@@ -472,6 +462,31 @@ component =
 
 ----------
 -- Component helper functions for variants
+
+-----
+-- Querying
+
+-- | When you are using several different types of child components in Formless
+-- | the component needs a child path to be able to pick the right slot to send
+-- | a query to.
+send :: ∀ pq cs cq form m a
+  . cs
+ -> cq a
+ -> Query pq cq cs form m a
+send p q = Send p q
+
+-- | When you are using several different types of child components in Formless
+-- | the component needs a child path to be able to pick the right slot to send
+-- | a query to.
+send' :: ∀ pq cq' cs' cs cq form m a
+  . ChildPath cq cq' cs cs'
+ -> cs
+ -> cq a
+ -> Query pq cq' cs' form m a
+send' path p q = Send (injSlot path p) (injQuery path q)
+
+-----
+-- Queries
 
 -- | A helper to create the correct `Modify` query for Formless given a label and
 -- | an input value

--- a/src/Formless.purs
+++ b/src/Formless.purs
@@ -43,7 +43,7 @@ import Control.Comonad (extract)
 import Control.Comonad.Store (Store, store)
 import Control.Monad.Free (liftF)
 import Data.Const (Const)
-import Data.Coyoneda (coyoneda)
+import Data.Coyoneda (liftCoyoneda)
 import Data.Eq (class EqRecord)
 import Data.Generic.Rep (class Generic)
 import Data.Generic.Rep.Show (genericShow)
@@ -317,7 +317,7 @@ component =
       st <- getState
       pure $ reply $ getPublicState st
 
-    Send cs cq -> H.HalogenM $ liftF $ H.ChildQuery cs $ coyoneda identity cq
+    Send cs cq -> H.HalogenM $ liftF $ H.ChildQuery cs $ liftCoyoneda cq
 
     Raise query a -> do
       H.raise (Emit query)
@@ -466,9 +466,7 @@ component =
 -----
 -- Querying
 
--- | When you are using several different types of child components in Formless
--- | the component needs a child path to be able to pick the right slot to send
--- | a query to.
+-- | For use when you need to query a component through Formless
 send :: ∀ pq cs cq form m a
   . cs
  -> cq a


### PR DESCRIPTION
## What does this pull request do?

Resolves https://github.com/thomashoneyman/purescript-halogen-formless/issues/28. Adds the ability to request data from child components as well as send actions. As of yet, this doesn't support the `queryAll` functionality of Halogen, but supports full `query` functionality.

## Where should the reviewer start?

Review the new `send` and `send'` functions, as well as the implementation of the `Send`query in the component's eval function. 

## How should this be manually tested?

Verify that resetting the `external-components` example also prints out the current items of one of the typeaheads.

## Other Notes:

This is a breaking change, so should either go into the `0.3.0` release or should trigger its own release.