### PR TITLE
Fix a bug in Reset

### DIFF
--- a/src/Formless/Component.purs
+++ b/src/Formless/Component.purs
@@ -72,10 +72,10 @@ component =
     , submitAttempts: 0
     , submitting: false
     , form: Internal.inputFieldsToFormFields initialInputs
-    , internal: InternalState 
+    , internal: InternalState
         { allTouched: false
         , initialInputs
-        , validators 
+        , validators
         , debounceRef: Nothing
         }
     }
@@ -84,12 +84,12 @@ component =
   eval = case _ of
     Initialize a -> do
       ref <- H.liftEffect $ Ref.new Nothing
-      modifyState_ \st -> st 
+      modifyState_ \st -> st
         { internal = over InternalState (_ { debounceRef = Just ref }) st.internal }
       pure a
 
     Modify variant a -> do
-      modifyState_ \st -> st 
+      modifyState_ \st -> st
         { form = Internal.unsafeModifyInputVariant identity variant st.form }
       eval $ SyncFormData a
 
@@ -102,8 +102,8 @@ component =
 
     -- Provided as a separate query to minimize state updates / re-renders
     ModifyValidate milliseconds variant a -> do
-      let 
-        modifyWith 
+      let
+        modifyWith
           :: (forall e o. FormFieldResult e o -> FormFieldResult e o)
           -> DSL pq cq cs form m (form Record FormField)
         modifyWith f = do
@@ -120,19 +120,19 @@ component =
       case milliseconds of
         Nothing -> do
           _ <- modifyWith identity
-          _ <- validate 
+          _ <- validate
           eval (SyncFormData a)
         Just ms -> do
-          debounceForm 
-            ms 
-            (modifyWith identity) 
-            (modifyWith (const Validating) *> validate) 
+          debounceForm
+            ms
+            (modifyWith identity)
+            (modifyWith (const Validating) *> validate)
             (eval $ SyncFormData a)
           pure a
-        
+
     Reset variant a -> do
       modifyState_ \st -> st
-        { form = Internal.replaceFormFieldInputs (unwrap st.internal).initialInputs st.form
+        { form = Internal.unsafeModifyInputVariant identity variant st.form
         , internal = over InternalState (_ { allTouched = false }) st.internal
         }
       eval $ SyncFormData a
@@ -237,9 +237,9 @@ component =
         , form = Internal.replaceFormFieldInputs formInputs st.form
         , internal = over
             InternalState
-            (_ 
+            (_
               { allTouched = false
-              , initialInputs = formInputs 
+              , initialInputs = formInputs
               }
             )
             st.internal

--- a/src/Formless/Query.purs
+++ b/src/Formless/Query.purs
@@ -288,12 +288,12 @@ reset
   :: ∀ pq cq cs form inputs m sym a t0 e i o
    . IsSymbol sym
   => Initial i
-  => Newtype (form Variant InputField) (Variant inputs)
-  => Row.Cons sym (InputField e i o) t0 inputs
+  => Newtype (form Variant InputFunction) (Variant inputs)
+  => Row.Cons sym (InputFunction e i o) t0 inputs
   => SProxy sym
   -> a
   -> Query pq cq cs form m a
-reset sym = Reset (wrap (inj sym (wrap initial)))
+reset sym = Reset (wrap (inj sym (wrap (const initial))))
 
 -- | `reset` as an action, so you don't need to specify a `Unit`
 -- | result. Use to skip a use of `Halogen.action`.
@@ -301,11 +301,11 @@ reset_
   :: ∀ pq cq cs form inputs m sym t0 e i o
    . IsSymbol sym
   => Initial i
-  => Newtype (form Variant InputField) (Variant inputs)
-  => Row.Cons sym (InputField e i o) t0 inputs
+  => Newtype (form Variant InputFunction) (Variant inputs)
+  => Row.Cons sym (InputFunction e i o) t0 inputs
   => SProxy sym
   -> Query pq cq cs form m Unit
-reset_ sym = Reset (wrap (inj sym (wrap initial))) unit
+reset_ sym = Reset (wrap (inj sym (wrap (const initial)))) unit
 
 -- | A helper to create the correct `Validate` query for Formless, given
 -- | a label

--- a/src/Formless/Types/Component.purs
+++ b/src/Formless/Types/Component.purs
@@ -23,7 +23,7 @@ data Query pq cq cs form m a
   = Modify (form Variant InputFunction) a
   | Validate (form Variant U) a
   | ModifyValidate (Maybe Milliseconds) (form Variant InputFunction) a
-  | Reset (form Variant InputField) a
+  | Reset (form Variant InputFunction) a
   | SetAll (form Record InputField) a
   | ModifyAll (form Record InputFunction) a
   | ResetAll a
@@ -92,10 +92,10 @@ newtype InternalState form m = InternalState
   }
 derive instance newtypeInternalState :: Newtype (InternalState form m) _
 
--- | A type to represent a running debouncer 
+-- | A type to represent a running debouncer
 type Debouncer =
   { var   :: AVar Unit
-  , fiber :: Fiber Unit 
+  , fiber :: Fiber Unit
   }
 
 -- | A type to represent validation status


### PR DESCRIPTION
## What does this pull request do?

This PR fixes a bug in the Reset functionality, where the handler would ignore the variant it received and reset the entire form instead of just the specific field the user was attempting to reset.

## Where should the reviewer start?

Ignore the whitespace changes and just examine the `Reset` handler as well as the `reset` and `reset_` helper functions.

## How should this be manually tested?

Run a local web server after compiling the examples and check that in the `real-world` example, changing the Admin value now correctly only clears the two secret key fields and not the entire form.

