### PR TITLE
Cancel long-running validation functions automatically

### DIFF
--- a/src/Formless/Component.purs
+++ b/src/Formless/Component.purs
@@ -77,15 +77,24 @@ component =
         , initialInputs
         , validators
         , debounceRef: Nothing
+        , validationRef: Nothing
         }
     }
 
   eval :: Query pq cq cs form m ~> DSL pq cq cs form m
   eval = case _ of
     Initialize a -> do
-      ref <- H.liftEffect $ Ref.new Nothing
+      dr <- H.liftEffect $ Ref.new Nothing
+      vr <- H.liftEffect $ Ref.new Nothing
       modifyState_ \st -> st
-        { internal = over InternalState (_ { debounceRef = Just ref }) st.internal }
+        { internal = over InternalState 
+            (_ 
+              { debounceRef = Just dr
+              , validationRef = Just vr
+              }
+            )
+            st.internal 
+        }
       pure a
 
     Modify variant a -> do

--- a/src/Formless/Types/Component.purs
+++ b/src/Formless/Types/Component.purs
@@ -9,7 +9,7 @@ import Data.Generic.Rep.Show (genericShow)
 import Data.Maybe (Maybe)
 import Data.Newtype (class Newtype)
 import Data.Variant (Variant)
-import Effect.Aff (Fiber, Milliseconds)
+import Effect.Aff (Error, Fiber, Milliseconds)
 import Effect.Aff.AVar (AVar)
 import Effect.Ref (Ref)
 import Formless.Types.Form (FormField, InputField, InputFunction, OutputField, U)
@@ -89,12 +89,13 @@ newtype InternalState form m = InternalState
   , validators :: form Record (Validation form m)
   , allTouched :: Boolean
   , debounceRef :: Maybe (Ref (Maybe Debouncer))
+  , validationRef :: Maybe (Ref (Maybe (Error -> m Unit)))
   }
 derive instance newtypeInternalState :: Newtype (InternalState form m) _
 
 -- | A type to represent a running debouncer
 type Debouncer =
-  { var   :: AVar Unit
+  { var :: AVar Unit
   , fiber :: Fiber Unit
   }
 


### PR DESCRIPTION
## What does this pull request do?

Unfortunately, the first implementation of async fields suffered from a race condition in which the user could stop typing long enough for the debouncer to run and validation to begin, then start typing again before validation finished. This would cause random overwrites of their form state depending on when the validation finally completed.

As you can see, if you type while the validation is running, your contents will be overwritten with those at the time the debouncer stopped and validation started:

![2018-12-04 23 43 52](https://user-images.githubusercontent.com/10245104/49498076-ca355400-f81e-11e8-9b24-11f192d8f6c5.gif)

This PR fixes the issue by cancelling any existing validations each time the debouncer is re-triggered. This is done through a ref to avoid re-renders. See how you can keep pressing characters to cancel & restart the validation:

![2018-12-04 23 44 50](https://user-images.githubusercontent.com/10245104/49498103-da4d3380-f81e-11e8-8940-73f3d28fabec.gif)

