### PR TITLE
Add Formless component template file

### DIFF
--- a/template/DataAndValidation.purs
+++ b/template/DataAndValidation.purs
@@ -1,0 +1,46 @@
+module Template.DataAndValidation where
+
+import Prelude
+
+import Data.Either (Either(..))
+import Data.Generic.Rep (class Generic)
+import Data.Generic.Rep.Show (genericShow)
+import Data.Lens (preview)
+import Data.Maybe (Maybe)
+import Data.Newtype (class Newtype)
+import Data.Symbol (SProxy(..))
+import Data.String.CodeUnits (length)
+import Formless (FormFieldResult, Validation, _Error, hoistFnE_)
+
+-- Data type for one of our fields
+
+newtype Name = Name String
+derive instance newtypeName :: Newtype Name _
+derive newtype instance showName :: Show Name
+
+type NAME_FIELD f r = (name :: f FieldError String String | r)
+
+_name :: SProxy "name"
+_name = SProxy
+
+-- Error type for one of our fields
+data FieldError
+  = TooShort Int
+
+derive instance genericFieldError :: Generic FieldError _
+instance showFieldError :: Show FieldError where
+  show = genericShow
+
+-- | Function for validating one of our field's data
+minLength :: ∀ form m. Monad m => Int -> Validation form m FieldError String String
+minLength n = hoistFnE_ $ \str ->
+  let n' = length str
+   in if n' < n then Left (TooShort n) else Right str
+
+-- | This could be a type class, but we'll just use a function instead.
+toErrorText :: FieldError -> String
+toErrorText (TooShort n) = "You must enter at least " <> show n <> " characters."
+
+-- | Unpacks errors to render as a string
+showError :: ∀ o. FormFieldResult FieldError o -> Maybe String
+showError = map toErrorText <<< preview _Error

--- a/template/FormlessTemplate.purs
+++ b/template/FormlessTemplate.purs
@@ -66,7 +66,9 @@ component = F.component mkInput $ F.defaultSpec
     , additionalState: Just 5
     }
 
-  render :: F.PublicState Form AddedState -> F.ComponentHTML Form Action ChildSlots Aff
+  render
+    :: F.PublicState Form AddedState
+    -> F.ComponentHTML Form Action ChildSlots Aff
   render st =
     HH.div_
       [ HH.p_ [ HH.text $ "Validity: " <> show st.validity ]
@@ -92,8 +94,9 @@ component = F.component mkInput $ F.defaultSpec
         [ HH.text "Submit" ]
       ]
 
-  handleEvent :: F.Event Form AddedState
-              -> F.HalogenM Form AddedState Action ChildSlots Message MonadType Unit
+  handleEvent
+    :: F.Event Form AddedState
+    -> F.HalogenM Form AddedState Action ChildSlots Message MonadType Unit
   handleEvent = case _ of
     F.Submitted formContent -> do
       -- This is how to get the output values of the form.
@@ -110,7 +113,9 @@ component = F.component mkInput $ F.defaultSpec
     F.Changed formState -> do
       void $ pure formState
 
-  handleAction :: Action -> F.HalogenM Form AddedState Action ChildSlots Message MonadType Unit
+  handleAction
+    :: Action
+    -> F.HalogenM Form AddedState Action ChildSlots Message MonadType Unit
   handleAction = case _ of
     DoStuff -> do
       pure unit
@@ -121,7 +126,10 @@ component = F.component mkInput $ F.defaultSpec
     Finalize -> do
       pure unit
 
-  handleQuery :: forall a. Query a -> F.HalogenM Form AddedState Action ChildSlots Message MonadType (Maybe a)
+  handleQuery
+    :: forall a
+     . Query a
+    -> F.HalogenM Form AddedState Action ChildSlots Message MonadType (Maybe a)
   handleQuery = case _ of
     Reply reply -> do
       pure $ Just $ reply unit

--- a/template/FormlessTemplate.purs
+++ b/template/FormlessTemplate.purs
@@ -1,0 +1,117 @@
+module FormlessTemplate where
+
+import Prelude
+
+import DOM.HTML.Indexed.InputType (InputType(..))
+import Data.Maybe (Maybe(..))
+import Data.Newtype (class Newtype)
+import Effect.Aff (Aff)
+import Formless as F
+import Halogen as H
+import Halogen.HTML as HH
+import Halogen.HTML.Events as HE
+import Halogen.HTML.Properties as HP
+import Template.DataAndValidation (NAME_FIELD, _name, minLength)
+import Type.Row (type (+))
+
+type FormFieldsRow f =
+  ( NAME_FIELD f
+  + ()
+  )
+
+type FormFields = { | FormFieldsRow F.OutputType }
+
+newtype Form r f = Form (r (FormFieldsRow f))
+derive instance newtypeForm' :: Newtype (Form r f) _
+
+-- Form component types
+
+type Input = Unit
+type AddedState = ()
+data Action
+  = DoStuff
+  | Initialize
+  | Finalize
+  | Receive Input
+
+data Query a
+  = Command a
+  | Reply (Unit -> a)
+
+type Message = FormFields
+type ChildSlots =
+  ()
+type MonadType = Aff
+type SelfSlot index = F.Slot Form Query ChildSlots Message index
+
+component :: F.Component Form Query ChildSlots Input FormFields Aff
+component = F.component mkInput $ F.defaultSpec
+  { render = render
+  , handleAction = handleAction
+  , handleEvent = handleEvent
+  , handleQuery = handleQuery
+  , initialize = Just Initialize
+  , finalize = Just Finalize
+  , receive = Just <<< Receive
+  }
+  where
+  mkInput :: Input -> F.Input Form AddedState Aff
+  mkInput _ =
+    { validators: Form
+        { name: minLength 7
+        }
+    , initialInputs: Nothing
+    }
+
+  render :: F.PublicState Form AddedState -> F.ComponentHTML Form Action ChildSlots Aff
+  render st =
+    HH.div_
+      [ HH.p_ [ HH.text $ "Validity: " <> show st.validity ]
+      , HH.p_ [ HH.text $ "Dirty: " <> show st.dirty ]
+      , HH.p_ [ HH.text $ "Being Submitted: " <> show st.submitting ]
+      , HH.p_ [ HH.text $ "Number of Errors: " <> show st.errors ]
+      , HH.p_ [ HH.text $ "Number of Submit attempts: " <> show st.submitAttempts ]
+      -- not sure how to use this value: `st.form`
+      , HH.div_
+        [ HH.text "Label" ]
+      , HH.input
+        [ HP.type_ InputText
+        , HP.placeholder "Michael"
+        , HP.value (F.getInput _name st.form)
+        , HE.onValueInput (Just <<< F.setValidate _name)
+        ]
+      , HH.button
+        [ if st.submitting || st.validity /= F.Valid
+            then HP.disabled true
+            else HE.onClick \_ -> Just F.submit
+        ]
+        [ HH.text "Submit" ]
+      ]
+
+  handleEvent :: F.Event Form AddedState
+              -> F.HalogenM Form AddedState Action ChildSlots Message MonadType Unit
+  handleEvent = case _ of
+    F.Submitted formContent -> do
+      let sendFormDataToParent = H.raise $ F.unwrapOutputFields formContent
+      -- but we don't call it in case you want a different message type
+      pure unit
+    F.Changed formState -> do
+      void $ pure formState
+
+  handleAction :: Action -> F.HalogenM Form AddedState Action ChildSlots Message MonadType Unit
+  handleAction = case _ of
+    DoStuff -> do
+      pure unit
+    Initialize -> do
+      pure unit
+    Receive input -> do
+      pure unit
+    Finalize -> do
+      pure unit
+
+  handleQuery :: forall a. Query a -> F.HalogenM Form AddedState Action ChildSlots Message MonadType (Maybe a)
+  handleQuery = case _ of
+    Reply reply -> do
+      pure $ Just $ reply unit
+    Command next -> do
+      pure $ Just next

--- a/template/FormlessTemplate.purs
+++ b/template/FormlessTemplate.purs
@@ -56,6 +56,8 @@ component = F.component mkInput $ F.defaultSpec
   , receive = Just <<< Receive
   }
   where
+  -- Converts the Input value passed in by the parent component
+  -- into the Formless' Input value.
   mkInput :: Input -> F.Input Form AddedState m
   mkInput _ =
     -- the two values here are for Formless

--- a/template/FormlessTemplate.purs
+++ b/template/FormlessTemplate.purs
@@ -104,7 +104,7 @@ component = F.component mkInput $ F.defaultSpec
 
       -- We won't do this here, but this is how most will handle a form
       -- submission: raise it as an event to their parent.
-      --      H.raise formFiels
+      --      H.raise formFields
 
       -- Alternatively, one could do something custom with the output values.
 

--- a/template/FormlessTemplate.purs
+++ b/template/FormlessTemplate.purs
@@ -96,6 +96,9 @@ component = F.component mkInput $ F.defaultSpec
         [ HH.text "Submit" ]
       ]
 
+  -- Decide what, if anything, to do when Formless events occur.
+  -- For example, if you would like to raise events as messages,
+  -- then use `F.raiseResult` as your `handleEvent` function.
   handleEvent
     :: F.Event Form AddedState
     -> F.HalogenM Form AddedState Action ChildSlots Message m Unit

--- a/template/FormlessTemplate.purs
+++ b/template/FormlessTemplate.purs
@@ -87,7 +87,11 @@ component = F.component mkInput $ F.defaultSpec
       , HH.input
         [ HP.type_ InputText
         , HP.placeholder "Michael"
-        , HP.value (F.getInput _name st.form) -- access one value in form
+
+        -- gets the value of `_name` in the form's state
+        , HP.value (F.getInput _name st.form)
+
+        -- sets the value of `_name` and then validates it
         , HE.onValueInput (Just <<< F.setValidate _name)
         ]
       , HH.button

--- a/template/FormlessTemplate.purs
+++ b/template/FormlessTemplate.purs
@@ -75,11 +75,29 @@ component = F.component mkInput $ F.defaultSpec
     -> F.ComponentHTML Form Action ChildSlots m
   render st =
     HH.div_
+      -- Indicates whether the form's values are valid
+      -- (i.e. validation has passed for all fields)
       [ HH.p_ [ HH.text $ "Validity: " <> show st.validity ]
+
+      -- Indicates whether any field in the form has been changed from
+      -- its initial state
       , HH.p_ [ HH.text $ "Dirty: " <> show st.dirty ]
+
+      -- Indicates whether the 'submit' button has been clicked and the
+      -- form's content is still being validated one last time before
+      -- submission is accepted.
       , HH.p_ [ HH.text $ "Being Submitted: " <> show st.submitting ]
+
+      -- Indicates the number of errors due to validation failing that
+      -- need to be fixed before submission is accepted
       , HH.p_ [ HH.text $ "Number of Errors: " <> show st.errors ]
+
+      -- Indicates the number of times user has attempted to submit the form
       , HH.p_ [ HH.text $ "Number of Submit attempts: " <> show st.submitAttempts ]
+
+      -- We can also refer to any additional labels we used to extend the
+      -- form's state; in this case, that means any field from our
+      -- `AddedState` type.
       , HH.p_ [ HH.text $ "Additional state was: " <> show st.additionalState ]
 
       , HH.div_
@@ -109,6 +127,7 @@ component = F.component mkInput $ F.defaultSpec
     :: F.Event Form AddedState
     -> F.HalogenM Form AddedState Action ChildSlots Message m Unit
   handleEvent = case _ of
+    -- Indicates that the form has been successfully submitted.
     F.Submitted formContent -> do
       -- This is how to get the output values of the form.
       let formFields = F.unwrapOutputFields formContent
@@ -121,6 +140,10 @@ component = F.component mkInput $ F.defaultSpec
 
       -- This line exists so the code compiles.
       pure unit
+
+    -- Indicates that the form's content has been changed.
+    -- This event is triggered anytime a field is changed,
+    -- whether it passes validation or not.
     F.Changed formState -> do
       void $ pure formState
 


### PR DESCRIPTION
## What does this pull request do?

Fixes #49

Also changes `halogen-storybook`'s branch from `halogen5` to `master` as the code wouldn't compile otherwise.

## Where should the reviewer start?

Read the 'other notes' section, skim the code and then answer my questions below

## How should this be manually tested?

AFAIK, we should only verify that this code compiles in the CI. 

## Other Notes:

There's a number of things that aren't correct in this PR with regard to the data type, `Name`.
- the output field of the row type isn't `Name` as it should be but `String`
- there might be a few type classes that `Name` unnecessarily implements (can't remember)
- ~there isn't an optic for `FieldError`, so the usage of `_Error` will likely stop compilation~
- there's no example of the `Initial` type class and how one would could implement it for `Name`

The halogen component part is basically the uncommented version of the template file. Since it's also lacking in a few other ways (more modular pieces that show how to use some of its API?), it would need to be completed before we could document it better. I'm not sure what should be included here and what should be left out because the `examples` folder already exists.

Questions I have:
- What else is `st.form` used for?
- I think the commented version should include 'additional state' as an example of its usage whereas the uncommented one should not. Your thoughts?
- I think this file should be separately licensed to ensure that one who uses it (since that's what it's for, right?) don't have to worry about satisfying such license constraints. Your thoughts?

Lastly, there's documenting each part in a clear manner.