### PR TITLE
Make examples compile again.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -19,7 +19,7 @@
     "tests"
   ],
   "dependencies": {
-    "purescript-halogen": "^5.0.0-rc.4",
+    "purescript-halogen": "^5.0.0-rc.6",
     "purescript-variant": "^6.0.0",
     "purescript-heterogeneous": "^0.4.0",
     "purescript-generics-rep": "^6.1.0",
@@ -28,6 +28,6 @@
   "devDependencies": {
     "purescript-debug": "^4.0.0",
     "purescript-halogen-select": "master",
-    "purescript-halogen-storybook": "halogen5"
+    "purescript-halogen-storybook": "master"
   }
 }

--- a/example/App/UI/Dropdown.purs
+++ b/example/App/UI/Dropdown.purs
@@ -56,15 +56,15 @@ data Message item
   | Cleared
 
 spec 
-  :: forall item m
+  :: forall item m i
    . MonadAff m 
   => ToText item
   => Eq item
-  => Select.Spec (State item) Query Void () (Message item) m
+  => Select.Spec (State item) Query Void () i (Message item) m
 spec = Select.defaultSpec
   { render = render 
   , handleQuery = handleQuery 
-  , handleMessage = handleMessage
+  , handleEvent = handleEvent
   }
   where
   render st =
@@ -79,7 +79,7 @@ spec = Select.defaultSpec
       H.raise Cleared
       pure (Just a)
 
-  handleMessage = case _ of
+  handleEvent = case _ of
     Select.Selected ix -> do
       st <- H.get
       let mbItem = st.available !! ix

--- a/example/App/UI/Typeahead.purs
+++ b/example/App/UI/Typeahead.purs
@@ -71,12 +71,12 @@ data Message f item
 -- Premade
 
 single
-  :: ∀ item m
+  :: ∀ item i m
    . MonadAff m
   => ToText item
   => Eq item
   => Semigroup item
-  => Select.Spec (State Maybe item) (Query item) (Action item) () (Message Maybe item) m
+  => Select.Spec (State Maybe item) (Query item) (Action item) () i (Message Maybe item) m
 single = spec' (\i av -> const (av !! i)) (const $ const Nothing) filter' render
   where
   filter' items Nothing = items
@@ -109,11 +109,11 @@ single = spec' (\i av -> const (av !! i)) (const $ const Nothing) filter' render
         ]
 
 multi
-  :: ∀ item m
+  :: ∀ item i m
    . MonadAff m
   => ToText item
   => Eq item
-  => Select.Spec (State Array item) (Query item) (Action item) () (Message Array item) m
+  => Select.Spec (State Array item) (Query item) (Action item) () i (Message Array item) m
 multi = spec' selectByIndex (filter <<< (/=)) difference render
   where
   selectByIndex ix available selected = case available !! ix of
@@ -154,7 +154,7 @@ multi = spec' selectByIndex (filter <<< (/=)) difference render
 -- Base component
 
 spec'
-  :: ∀ item f m
+  :: ∀ item f i m
    . MonadAff m
   => Functor f
   => Monoid (f item)
@@ -166,15 +166,15 @@ spec'
   -> (Select.State (State f item) 
        -> H.ComponentHTML (Select.Action (Action item)) () m
      )
-  -> Select.Spec (State f item) (Query item) (Action item) () (Message f item) m
+  -> Select.Spec (State f item) (Query item) (Action item) () i (Message f item) m
 spec' select' remove' filter' render' = Select.defaultSpec
   { render = render' 
-  , handleMessage = handleMessage 
+  , handleEvent = handleEvent
   , handleQuery = handleQuery
   , handleAction = handleAction
   }
   where
-  handleMessage = case _ of
+  handleEvent = case _ of
     Select.Searched string -> do
       st <- H.get
       let items = filter (String.contains (String.Pattern string) <<< toText) st.items

--- a/example/external-components/Form.purs
+++ b/example/external-components/Form.purs
@@ -200,6 +200,6 @@ component = F.component (const defaultInput) $ F.defaultSpec
       ]
 
     singleTypeahead slot input =
-      HH.slot TA._typeahead slot (Select.component TA.single) (TA.input input) handler
+      HH.slot TA._typeahead slot (Select.component TA.input TA.single) input handler
       where
       handler = Just <<< F.injAction <<< HandleTypeahead slot

--- a/example/real-world/GroupForm.purs
+++ b/example/real-world/GroupForm.purs
@@ -119,7 +119,7 @@ derive instance ordTASlot :: Ord TASlot
 -- Form spec
 
 prx :: F.SProxies GroupForm
-prx = F.mkSProxies $ F.FormProxy :: _ GroupForm
+prx = F.mkSProxies (F.FormProxy :: _ GroupForm)
 
 component :: F.Component GroupForm (Const Void) ChildSlots Unit Group Aff
 component = F.component (const input) $ F.defaultSpec
@@ -302,10 +302,10 @@ component = F.component (const input) $ F.defaultSpec
       , help: F.getResult prx.admin form # UI.resultToHelp
           "Choose an administrator for the account"
       }
-      [ HH.slot DD._dropdown unit (Select.component DD.spec) ddInput handler ]
+      [ HH.slot DD._dropdown unit (Select.component DD.input DD.spec) ddInput handler ]
       where
       handler = Just <<< F.injAction <<< HandleDropdown
-      ddInput = DD.input
+      ddInput =
         { placeholder: "Choose an admin"
         , items: map (Admin <<< { id: _ })
             [ Nothing
@@ -323,10 +323,10 @@ component = F.component (const input) $ F.defaultSpec
       , help: F.getResult prx.whiskey form # UI.resultToHelp
           "Choose a whiskey to be awarded"
       }
-      [ HH.slot TA._typeaheadSingle unit (Select.component TA.single) taInput handler ]
+      [ HH.slot TA._typeaheadSingle unit (Select.component TA.input TA.single) taInput handler ]
       where
       handler = Just <<< F.injAction <<< HandleTASingle
-      taInput = TA.input
+      taInput =
         { placeholder: "Choose a whiskey"
         , items:
             [ "Laphroiag 10"
@@ -343,9 +343,9 @@ component = F.component (const input) $ F.defaultSpec
       }
       [ HH.slot TA._typeaheadMulti Pixels selectComponent taInput handler ]
       where
-      selectComponent = Select.component TA.multi
+      selectComponent = Select.component TA.input TA.multi
       handler = Just <<< F.injAction <<< HandleTAMulti Pixels
-      taInput = TA.input
+      taInput =
         { placeholder: "Search pixels"
         , items:
             [ "My favorite pixel"
@@ -362,9 +362,9 @@ component = F.component (const input) $ F.defaultSpec
       }
       [ HH.slot TA._typeaheadMulti Applications selectComponent taInput handler ]
       where
-      selectComponent = Select.component TA.multi
+      selectComponent = Select.component TA.input TA.multi
       handler = Just <<< F.injAction <<< HandleTAMulti Applications
-      taInput = TA.input
+      taInput =
         { placeholder: "Search one or more applications"
         , items: [ "Facebook", "Google", "Twitter", "Pinterest" ]
         }

--- a/example/real-world/OptionsForm.purs
+++ b/example/real-world/OptionsForm.purs
@@ -109,7 +109,7 @@ type ChildSlots =
 -- Form spec
 
 prx :: F.SProxies OptionsForm
-prx = F.mkSProxies $ F.FormProxy :: _ OptionsForm
+prx = F.mkSProxies (F.FormProxy :: _ OptionsForm)
 
 component :: F.Component OptionsForm (Const Void) ChildSlots Unit Message Aff
 component = F.component (const input) $ F.defaultSpec
@@ -163,7 +163,7 @@ component = F.component (const input) $ F.defaultSpec
       when (st.prevEnabled /= enabled) case enabled of
         true -> do
           let
-            initial = F.mkInputFields $ F.FormProxy :: _ OptionsForm
+            initial = F.mkInputFields (F.FormProxy :: _ OptionsForm)
             new = over OptionsForm (_ { enable = F.InputField true }) initial
           eval $ F.loadForm new
         _ ->
@@ -212,10 +212,10 @@ component = F.component (const input) $ F.defaultSpec
       , help: F.getResult prx.metric form # UI.resultToHelp
           "Choose a metric to optimize for."
       }
-      [ HH.slot DD._dropdown unit (Select.component DD.spec) ddInput handler ]
+      [ HH.slot DD._dropdown unit (Select.component DD.input DD.spec) ddInput handler ]
       where
       handler = Just <<< F.injAction <<< HandleDropdown
-      ddInput = DD.input
+      ddInput =
         { placeholder: "Choose a metric"
         , items: [ ViewCost, ClickCost, InstallCost ]
         }


### PR DESCRIPTION
## What does this pull request do?

This PR fixes the examples.

Updated dependency on `purescript-halogen-storybook` and `purescript-halogen`.

`purescript-halogen-select` has moved on since the last time the `halogen-5` branch was updated. The new parser in PS 0.13 also made some changes necessary.
