### PR TITLE
Remove symlink causing spago install failures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
 
       # Persist generated files into the workspace
       - run:
-          name: Replace symlinks with actual files
+          name: Copy Storybook CSS into dist
           command: |
             mv ~/formless/bower_components/purescript-halogen-storybook/examples/src/Storybook.css ~/formless/dist/storybook.css
 

--- a/dist/storybook.css
+++ b/dist/storybook.css
@@ -1,1 +1,0 @@
-../bower_components/purescript-halogen-storybook/examples/src/Storybook.css


### PR DESCRIPTION
## What does this pull request do?

Fixes https://github.com/spacchetti/spago/issues/394 and https://github.com/thomashoneyman/purescript-halogen-realworld/issues/43 by removing an invalid symlink from the `dist` directory. 

The symlink was previously used as a placeholder to replace with the actual CSS file in continuous integration for building the documentation site. It's not necessary, however, and is breaking Spago installations.

This PR removes the symlink and updates the continuous integration step to simply copy the file.

## Other Notes:

This will need to be followed up by a new pre-release and updates to the package set to avoid breaking further installations.