### PR TITLE
Makes sure that the last captured input is used to run validations instead of the first input

### DIFF
--- a/src/Formless/Component.purs
+++ b/src/Formless/Component.purs
@@ -237,9 +237,10 @@ handleAction handleAction' handleEvent action = flip match action
   , validate: \variant -> do
       st <- H.get
       let validators = (unwrap st.internal).validators
-      form <- H.lift do
+      formProcessor <- H.lift do
         IT.unsafeRunValidationVariant variant validators st.form
-      H.modify_ _ { form = form }
+      st' <- H.get
+      H.modify_ _ { form = formProcessor st'.form }
       handleAction handleAction' handleEvent sync
 
   , modifyValidate: \(Tuple milliseconds variant) -> do
@@ -255,10 +256,12 @@ handleAction handleAction' handleEvent action = flip match action
         validate = do
           st <- H.get
           let vs = (unwrap st.internal).validators
-          form <- H.lift do
+          formProcessor <- H.lift do
             IT.unsafeRunValidationVariant (unsafeCoerce variant) vs st.form
-          H.modify_ _ { form = form }
-          pure form
+          st' <- H.get
+          let newForm = formProcessor st'.form
+          H.modify_ _ { form = newForm }
+          pure newForm
 
       case milliseconds of
         Nothing ->

--- a/src/Formless/Internal/Transform.purs
+++ b/src/Formless/Internal/Transform.purs
@@ -184,19 +184,18 @@ unsafeRunValidationVariant
   => form Variant U
   -> form Record (Validation form m)
   -> form Record FormField
-  -> m (form Record FormField)
+  -> m ((form Record FormField) -> (form Record FormField))
 unsafeRunValidationVariant var vs rec = rec2
   where
     label :: String
     label = case unsafeCoerce (unwrap var) of
       VariantRep x -> x.type
 
-    rec2 :: m (form Record FormField)
+    rec2 :: m ((form Record FormField) -> (form Record FormField))
     rec2 = case unsafeGet label (unwrap rec) of
       FormField x -> do
         res <- runValidation (unsafeGet label $ unwrap vs) rec x.input
-        let rec' = unsafeSet label (FormField $ x { result = fromEither res }) (unwrap rec)
-        pure (wrap rec')
+        pure (\newRec -> wrap $ unsafeSet label (FormField $ x { result = fromEither res }) (unwrap newRec))
 
 -----
 -- Classes (Internal)

--- a/src/Formless/Types/Component.purs
+++ b/src/Formless/Types/Component.purs
@@ -20,6 +20,7 @@ import Type.Row (type (+))
 import Halogen as H
 import Halogen.HTML as HH
 import Halogen.Query.ChildQuery (ChildQueryBox)
+import Halogen.Query.HalogenM (ForkId)
 
 -- | A type representing the various functions that can be provided to extend
 -- | the Formless component. Usually only the `render` function is required,
@@ -160,6 +161,7 @@ derive instance newtypeInternalState :: Newtype (InternalState form m) _
 type Debouncer =
   { var :: AVar Unit
   , fiber :: Fiber Unit
+  , forkId :: ForkId
   }
 
 -- | A type to represent validation status


### PR DESCRIPTION
This change fixes the bug that is described as 'problem 1' in https://github.com/thomashoneyman/purescript-halogen-formless/issues/48#issuecomment-577846309.
