### PR TITLE
Update hooks version for PureScript v0.14

### DIFF
--- a/example/Example/Basic.purs
+++ b/example/Example/Basic.purs
@@ -5,7 +5,7 @@ module Example.Basic where
 import Prelude
 
 import Data.Either (note)
-import Data.Maybe (Maybe(..), isNothing)
+import Data.Maybe (isNothing)
 import Data.String.NonEmpty as NES
 import Effect.Class (class MonadEffect, liftEffect)
 import Example.Field.Basic.Text (textField)
@@ -20,7 +20,7 @@ import Web.Event.Event (preventDefault)
 import Web.HTML as HTML
 import Web.HTML.Window as Window
 
-basic :: forall q i o m. MonadEffect m => H.Component HH.HTML q i o m
+basic :: forall q i o m. MonadEffect m => H.Component q i o m
 basic = Hooks.component \_ _ -> Hooks.do
   form <- useForm (\_ -> initialFormState) $ buildForm
     { name: textField proxy
@@ -31,7 +31,7 @@ basic = Hooks.component \_ _ -> Hooks.do
 
   Hooks.pure do
     HH.form
-      [ HE.onSubmit \event -> Just $ liftEffect do
+      [ HE.onSubmit \event -> liftEffect do
           preventDefault event
           HTML.window >>= Window.alert (show form.value)
       ]

--- a/example/Example/Basic.purs
+++ b/example/Example/Basic.purs
@@ -15,7 +15,7 @@ import Halogen.HTML.Events as HE
 import Halogen.HTML.Properties as HP
 import Halogen.Hooks as Hooks
 import Halogen.Hooks.Formless (buildForm, initialFormState, useForm)
-import Type.Proxy (Proxy2(..))
+import Type.Proxy (Proxy(..))
 import Web.Event.Event (preventDefault)
 import Web.HTML as HTML
 import Web.HTML.Window as Window
@@ -47,4 +47,4 @@ basic = Hooks.component \_ _ -> Hooks.do
   -- We are using the compiler to infer our form type. When doing this, we need
   -- to provide a proxy for our monad type, `m`, to each of our form inputs. This
   -- aids the compiler in type inference.
-  proxy = Proxy2 :: Proxy2 m
+  proxy = Proxy :: Proxy m

--- a/example/Example/BasicAnnotated.purs
+++ b/example/Example/BasicAnnotated.purs
@@ -19,7 +19,7 @@ import Halogen.HTML.Properties as HP
 import Halogen.Hooks (HookM)
 import Halogen.Hooks as Hooks
 import Halogen.Hooks.Formless (FormField(..), buildForm, initialFormState, useForm)
-import Type.Proxy (Proxy2(..))
+import Type.Proxy (Proxy(..))
 import Web.Event.Event (preventDefault)
 import Web.HTML as HTML
 import Web.HTML.Window as Window
@@ -31,8 +31,8 @@ type Form f m =
 
 fields :: forall m. Form FormField m
 fields =
-  { name: textField Proxy2 { validate: note "Name is required." <<< NES.fromString }
-  , message: FormField Proxy2 \field -> Hooks.pure
+  { name: textField Proxy { validate: note "Name is required." <<< NES.fromString }
+  , message: FormField Proxy \field -> Hooks.pure
       { input:
           HH.div_
             [ HH.input

--- a/example/Example/BasicAnnotated.purs
+++ b/example/Example/BasicAnnotated.purs
@@ -7,7 +7,7 @@ module Example.BasicAnnotated where
 import Prelude
 
 import Data.Either (note)
-import Data.Maybe (Maybe(..), fromMaybe, isNothing)
+import Data.Maybe (fromMaybe, isNothing)
 import Data.String.NonEmpty (NonEmptyString)
 import Data.String.NonEmpty as NES
 import Effect.Class (class MonadEffect, liftEffect)
@@ -37,20 +37,20 @@ fields =
           HH.div_
             [ HH.input
                 [ HP.value (fromMaybe "" field.value)
-                , HE.onValueInput (Just <<< field.onChange)
+                , HE.onValueInput field.onChange
                 ]
             ]
       , value: field.value
       }
   }
 
-basic :: forall q i o m. MonadEffect m => H.Component HH.HTML q i o m
+basic :: forall q i o m. MonadEffect m => H.Component q i o m
 basic = Hooks.component \_ _ -> Hooks.do
   form <- useForm (\_ -> initialFormState) (buildForm fields)
 
   Hooks.pure do
     HH.form
-      [ HE.onSubmit \ev -> Just $ liftEffect do
+      [ HE.onSubmit \ev -> liftEffect do
           preventDefault ev
           HTML.window >>= Window.alert (show form.value)
       ]

--- a/example/Example/Dependency.purs
+++ b/example/Example/Dependency.purs
@@ -16,7 +16,7 @@ import Halogen.HTML as HH
 import Halogen.HTML.Events as HE
 import Halogen.Hooks as Hooks
 import Halogen.Hooks.Formless (buildForm, initialFormState, useFormFields, useFormState)
-import Type.Proxy (Proxy2(..))
+import Type.Proxy (Proxy(..))
 import Web.Event.Event (preventDefault)
 
 mutualDependency :: forall q i o m. MonadEffect m => H.Component q i o m
@@ -46,4 +46,4 @@ mutualDependency = Hooks.component \_ _ -> Hooks.do
       , form.fields.confirm.input
       ]
   where
-  proxy = Proxy2 :: Proxy2 m
+  proxy = Proxy :: Proxy m

--- a/example/Example/Dependency.purs
+++ b/example/Example/Dependency.purs
@@ -5,7 +5,7 @@ module Example.Dependency where
 import Prelude
 
 import Data.Either (Either(..), note)
-import Data.Maybe (Maybe(..), fromMaybe)
+import Data.Maybe (fromMaybe)
 import Data.String.NonEmpty as NES
 import Data.Tuple.Nested ((/\))
 import Effect.Class (class MonadEffect)
@@ -19,7 +19,7 @@ import Halogen.Hooks.Formless (buildForm, initialFormState, useFormFields, useFo
 import Type.Proxy (Proxy2(..))
 import Web.Event.Event (preventDefault)
 
-mutualDependency :: forall q i o m. MonadEffect m => H.Component HH.HTML q i o m
+mutualDependency :: forall q i o m. MonadEffect m => H.Component q i o m
 mutualDependency = Hooks.component \_ _ -> Hooks.do
   formState /\ modifyFormState <- useFormState (\_ -> initialFormState)
 
@@ -40,7 +40,7 @@ mutualDependency = Hooks.component \_ _ -> Hooks.do
 
   Hooks.pure do
     HH.form
-      [ HE.onSubmit \ev -> Just (liftEffect $ preventDefault ev) ]
+      [ HE.onSubmit \ev -> (liftEffect $ preventDefault ev) ]
       [ form.fields.name.input
       , form.fields.password.input
       , form.fields.confirm.input

--- a/example/Example/Field/Basic/Text.purs
+++ b/example/Example/Field/Basic/Text.purs
@@ -13,7 +13,7 @@ import Halogen.HTML.Properties as HP
 import Halogen.Hooks (class HookNewtype, HookM, HookType)
 import Halogen.Hooks as Hooks
 import Halogen.Hooks.Formless (FormField(..))
-import Type.Proxy (Proxy2)
+import Type.Proxy (Proxy)
 
 foreign import data UseBasicTextField :: Type -> HookType
 
@@ -39,7 +39,7 @@ type BasicTextFieldInterface m = ( input :: H.ComponentHTML (HookM m Unit) () m 
 -- | in your application.
 textField
   :: forall m a
-   . Proxy2 m
+   . Proxy m
   -> BasicTextFieldInput a
   -> FormField m (UseBasicTextField a) (BasicTextFieldInterface m) String a
 textField proxy { validate } = FormField proxy \field -> Hooks.wrap Hooks.do

--- a/example/Example/Field/Basic/Text.purs
+++ b/example/Example/Field/Basic/Text.purs
@@ -10,7 +10,7 @@ import Halogen.HTML as HH
 import Halogen.HTML.Events as HE
 import Halogen.HTML.Properties (InputType(..))
 import Halogen.HTML.Properties as HP
-import Halogen.Hooks (class HookEquals, class HookNewtype, HookM, kind HookType)
+import Halogen.Hooks (class HookNewtype, HookM, HookType)
 import Halogen.Hooks as Hooks
 import Halogen.Hooks.Formless (FormField(..))
 import Type.Proxy (Proxy2)
@@ -22,8 +22,7 @@ type UseBasicTextField' a =
     Hooks.<> Hooks.Pure
 
 instance newtypeUseBasicTextField
-  :: HookEquals (UseBasicTextField' a) h
-  => HookNewtype (UseBasicTextField a) h
+  :: HookNewtype (UseBasicTextField a) (UseBasicTextField' a)
 
 type BasicTextFieldInput a =
   { validate :: String -> Either String a
@@ -58,7 +57,7 @@ textField proxy { validate } = FormField proxy \field -> Hooks.wrap Hooks.do
         [ HH.input
             [ HP.type_ InputText
             , HP.value currentValue
-            , HE.onValueInput (Just <<< field.onChange)
+            , HE.onValueInput field.onChange
             ]
         , case field.value of
             Nothing -> HH.text ""

--- a/example/Main.purs
+++ b/example/Main.purs
@@ -6,7 +6,9 @@ import Data.Maybe (Maybe(..))
 import Data.Tuple (Tuple(..))
 import Effect (Effect)
 import Effect.Aff (Aff)
-import Example.Basic (basic)
+import Example.Basic as Basic
+import Example.BasicAnnotated as BasicAnnotated
+import Example.Dependency (mutualDependency)
 import Foreign.Object as Object
 import Halogen as H
 import Halogen.Aff as HA
@@ -18,8 +20,9 @@ import Type.Proxy (Proxy(..))
 stories :: Stories Aff
 stories = Object.fromFoldable
   [ Tuple "" $ proxy home
-  , Tuple "basic" $ proxy $ H.mkComponent { initialState: identity, eval: H.mkEval H.defaultEval, render: \_ -> HH.slot (Proxy :: Proxy "?") 0 basic {} absurd }
-  -- , Tuple "mutual-dependency" $ proxy $ H.mkComponent { initialState: identity, eval: H.mkEval H.defaultEval, render: \_ -> HH.slot (SProxy :: SProxy "!") 0 mutualDependency {} absurd }
+  , Tuple "basic" $ proxy $ H.mkComponent { initialState: identity, eval: H.mkEval H.defaultEval, render: \_ -> HH.slot (Proxy :: Proxy "?") 0 Basic.basic {} absurd }
+  , Tuple "basic-annotated" $ proxy $ H.mkComponent { initialState: identity, eval: H.mkEval H.defaultEval, render: \_ -> HH.slot (Proxy :: Proxy "??") 0 BasicAnnotated.basic {} absurd }
+  , Tuple "mutual-dependency" $ proxy $ H.mkComponent { initialState: identity, eval: H.mkEval H.defaultEval, render: \_ -> HH.slot (Proxy :: Proxy "!") 0 mutualDependency {} absurd }
   -- , Tuple "external-components" $ proxy ExternalComponents.component
   -- , Tuple "async" $ proxy Async.component
   -- , Tuple "nested" $ proxy Nested.component

--- a/example/Main.purs
+++ b/example/Main.purs
@@ -3,24 +3,23 @@ module Main where
 import Prelude
 
 import Data.Maybe (Maybe(..))
-import Data.Symbol (SProxy(..))
 import Data.Tuple (Tuple(..))
 import Effect (Effect)
 import Effect.Aff (Aff)
 import Example.Basic (basic)
-import Example.MutualDependency (mutualDependency)
 import Foreign.Object as Object
 import Halogen as H
 import Halogen.Aff as HA
 import Halogen.HTML as HH
 import Halogen.HTML.Properties as HP
 import Halogen.Storybook (Stories, runStorybook, proxy)
+import Type.Proxy (Proxy(..))
 
 stories :: Stories Aff
 stories = Object.fromFoldable
   [ Tuple "" $ proxy home
-  , Tuple "basic" $ proxy $ H.mkComponent { initialState: identity, eval: H.mkEval H.defaultEval, render: \_ -> HH.slot (SProxy :: SProxy "?") 0 basic {} absurd }
-  , Tuple "mutual-dependency" $ proxy $ H.mkComponent { initialState: identity, eval: H.mkEval H.defaultEval, render: \_ -> HH.slot (SProxy :: SProxy "!") 0 mutualDependency {} absurd }
+  , Tuple "basic" $ proxy $ H.mkComponent { initialState: identity, eval: H.mkEval H.defaultEval, render: \_ -> HH.slot (Proxy :: Proxy "?") 0 basic {} absurd }
+  -- , Tuple "mutual-dependency" $ proxy $ H.mkComponent { initialState: identity, eval: H.mkEval H.defaultEval, render: \_ -> HH.slot (SProxy :: SProxy "!") 0 mutualDependency {} absurd }
   -- , Tuple "external-components" $ proxy ExternalComponents.component
   -- , Tuple "async" $ proxy Async.component
   -- , Tuple "nested" $ proxy Nested.component

--- a/packages.dhall
+++ b/packages.dhall
@@ -2,3 +2,27 @@ let upstream =
       https://github.com/purescript/package-sets/releases/download/psc-0.14.0-20210329/packages.dhall sha256:32c90bbcd8c1018126be586097f05266b391f6aea9125cf10fba2292cb2b8c73
 
 in  upstream
+  with halogen-select =
+    { repo = "https://github.com/PureFunctor/purescript-halogen-select"
+    , dependencies =
+      [ "halogen"
+      , "halogen-hooks"
+      , "halogen-hooks-extra"
+      ]
+    , version = "master"
+    }
+
+  with halogen-storybook =
+    { repo = "https://github.com/rnons/purescript-halogen-storybook"
+    , dependencies =
+      [ "console"
+      , "debug"
+      , "effect"
+      , "foreign-object"
+      , "halogen"
+      , "psci-support"
+      , "routing"
+      ]
+    , version = "v1.0.1"
+    }
+

--- a/packages.dhall
+++ b/packages.dhall
@@ -1,6 +1,4 @@
 let upstream =
-      https://github.com/purescript/package-sets/releases/download/psc-0.13.8-20201021/packages.dhall sha256:55ebdbda1bd6ede4d5307fbc1ef19988c80271b4225d833c8d6fb9b6fb1aa6d8
+      https://github.com/purescript/package-sets/releases/download/psc-0.14.0-20210329/packages.dhall sha256:32c90bbcd8c1018126be586097f05266b391f6aea9125cf10fba2292cb2b8c73
 
 in  upstream
-  with halogen.version = "master"
-  with halogen-hooks.version = "main"

--- a/src/Halogen/Hooks/Formless.purs
+++ b/src/Halogen/Hooks/Formless.purs
@@ -398,16 +398,6 @@ instance foldingInitialFormState ::
   foldingWithIndex _ sym builder _ =
     builder >>> Builder.insert sym (TE.to Nothing)
 
-instance hfoldlInitialFormState ::
-  ( TE.TypeEquals (Maybe i) formFieldState
-  , Row.Cons sym formFieldState rb rc
-  , Row.Lacks sym rb
-  , IsSymbol sym
-  ) =>
-  HFoldlWithIndex InitialFormState (Builder { | ra } { | rb}) (Proxy formFieldState) (Builder { | ra} { | rc }) where
-  hfoldlWithIndex _ builder _ =
-    builder >>> Builder.insert (Proxy :: _ sym) (TE.to Nothing)
-
 -- | A helper function to build an initial form state where all fields are
 -- | initialized to `Nothing`. This function should be provided to the `useForm`
 -- | or `useFormState` Hooks as an argument.

--- a/src/Halogen/Hooks/Formless.purs
+++ b/src/Halogen/Hooks/Formless.purs
@@ -18,6 +18,7 @@ module Halogen.Hooks.Formless
   , BuildFormFor
   , initialFormState
   , InitialFormState
+  , UseMergedFormFields
   ) where
 
 import Prelude

--- a/src/Halogen/Hooks/Formless.purs
+++ b/src/Halogen/Hooks/Formless.purs
@@ -37,7 +37,7 @@ import Record as Record
 import Record.Builder (Builder)
 import Record.Builder as Builder
 import Type.Equality as TE
-import Type.Proxy (Proxy(..), Proxy2)
+import Type.Proxy (Proxy(..))
 import Unsafe.Coerce (unsafeCoerce)
 
 -- | Input provided to a `FormField`, which can be used to implement the field.
@@ -67,7 +67,7 @@ type FormFieldInput m i =
 -- | - `i`: The input type for this form field.
 -- | - `o`: The output type for this form field. A form is only considered valid
 -- |   when output types are present for all fields in the form.
-data FormField m h ro i o = FormField (Proxy2 m) (FormFieldInput m i -> Hooks.Hook m h { value :: Maybe o | ro })
+data FormField m h ro i o = FormField (Proxy m) (FormFieldInput m i -> Hooks.Hook m h { value :: Maybe o | ro })
 
 -- | The interface returned by the `useForm` and `useFormFields` Hooks.
 -- |

--- a/src/Halogen/Hooks/Formless.purs
+++ b/src/Halogen/Hooks/Formless.purs
@@ -28,10 +28,9 @@ import Data.Tuple (Tuple)
 import Data.Tuple.Nested ((/\), type (/\))
 import Halogen.Hooks (HookM)
 import Halogen.Hooks as Hooks
-import Halogen.Hooks.Hook (HProxy)
 import Heterogeneous.Folding (class FoldingWithIndex, class HFoldlWithIndex, hfoldlWithIndex)
 import Prim.Row as Row
-import Prim.RowList (class RowToList, kind RowList)
+import Prim.RowList (class RowToList, RowList)
 import Prim.RowList as RowList
 import Record as Record
 import Record.Builder (Builder)
@@ -94,11 +93,10 @@ type UseForm' form m h =
 
 -- | The Hook type for `useForm`, which accepts the form row, monad type, and
 -- | form fields Hook type (typically UseBuildForm) as arguments.
-foreign import data UseForm :: # Type -> (Type -> Type) -> Hooks.HookType -> Hooks.HookType
+foreign import data UseForm :: Row Type -> (Type -> Type) -> Hooks.HookType -> Hooks.HookType
 
 instance newtypeUseForm
-  :: Hooks.HookEquals x (UseForm' form m h)
-  => Hooks.HookNewtype (UseForm form m h) x
+  :: Hooks.HookNewtype (UseForm form m h) (UseForm' form m h)
 
 -- | A Hook for managing forms with Formless. Combines `useFormState` and
 -- | `useFormFields` to manage form state and form fields.
@@ -135,8 +133,7 @@ type UseFormState' form = Hooks.UseState (FormState form)
 foreign import data UseFormState :: Type -> Hooks.HookType
 
 instance newtypeUseFormState
-  :: Hooks.HookEquals h (UseFormState' form)
-  => Hooks.HookNewtype (UseFormState form) h
+  :: Hooks.HookNewtype (UseFormState form) (UseFormState' form)
 
 -- | A Hook for managing form state with Formless. Requires a function to produce
 -- | the initial form state, which is usually `\_ -> initialFormState`.
@@ -173,11 +170,10 @@ type UseFormFields' form m h =
 
 -- | The Hook type for `UseFormFields`, which accepts the form row, monad, and
 -- | hook type (typically `UseBuildForm`) as arguments.
-foreign import data UseFormFields :: # Type -> (Type -> Type) -> Hooks.HookType -> Hooks.HookType
+foreign import data UseFormFields :: Row Type -> (Type -> Type) -> Hooks.HookType -> Hooks.HookType
 
 instance newtypeUseFormFields
-  :: Hooks.HookEquals x (UseFormFields' form m h)
-  => Hooks.HookNewtype (UseFormFields form m h) x
+  :: Hooks.HookNewtype (UseFormFields form m h) (UseFormFields' form m h)
 
 -- | A Hook for managing form fields with Formless. Requires a state tuple to
 -- | read and modify the form state, provided by `Formless.useFormState`, and a
@@ -234,7 +230,7 @@ type BuildFormFieldInput form m =
 -- |   , field2: FormField \field -> ...
 -- |   }
 -- | ```
-newtype BuildFormField (closed :: # Type) form m h fields value =
+newtype BuildFormField (closed :: Row Type) form m h fields value =
   BuildFormField
     (BuildFormFieldInput form m
       -> Hooks.Hook m h { fields :: { | fields }, value :: Maybe { | value }})
@@ -246,8 +242,7 @@ type UseFormField' h1 = h1 Hooks.<> Hooks.Pure
 foreign import data UseFormField :: Hooks.HookType -> Hooks.HookType
 
 instance newtypeUseFormField
-  :: Hooks.HookEquals x (UseFormField' h1)
-  => Hooks.HookNewtype (UseFormField h1) x
+  :: Hooks.HookNewtype (UseFormField h1) (UseFormField' h1)
 
 -- | An internal helper function for building a single form field.
 buildFormField
@@ -284,8 +279,7 @@ type UseMergedFormFields' h1 h2 =
 foreign import data UseMergedFormFields :: Hooks.HookType -> Hooks.HookType -> Hooks.HookType
 
 instance newtypeUseMergedFormFields
-  :: Hooks.HookEquals x (UseMergedFormFields' h1 h2)
-  => Hooks.HookNewtype (UseMergedFormFields h1 h2) x
+  :: Hooks.HookNewtype (UseMergedFormFields h1 h2) (UseMergedFormFields' h1 h2)
 
 -- | An internal helper function for merging form fields to produce a single
 -- | resulting form.
@@ -305,7 +299,7 @@ mergeFormFields (BuildFormField step1) (BuildFormField step2) =
     let value = Record.union <$> result1.value <*> result2.value
     Hooks.pure { fields, value }
 
-foreign import data UseBuildForm :: # Type -> Hooks.HookType
+foreign import data UseBuildForm :: Row Type -> Hooks.HookType
 
 -- | Build a form from a record of form fields, which can then be passed to
 -- | `useForm` or `useFormFields` to produce your full form.
@@ -332,7 +326,7 @@ buildForm
   => Row.Cons sym (Maybe i) () closed2
   => Row.Cons sym { value :: Maybe o | ro } () fields2
   => Row.Cons sym o () value2
-  => Row.Cons sym (HProxy h2) hform' hform
+  => Row.Cons sym (Proxy h2) hform' hform
   => Row.Lacks sym ()
   => { | r }
   -> BuildFormField closed3 form m (UseBuildForm hform) fields3 value3
@@ -349,9 +343,11 @@ buildForm inputs = do
     -> BuildFormField closed3 form m (UseBuildForm hform) fields3 value3) $
     buildFormStep (BuildFormFor inputs :: BuildFormFor r tail) builder
 
-newtype BuildFormFor (r :: # Type) (rl :: RowList) = BuildFormFor { | r }
+newtype BuildFormFor :: forall t. Row Type -> RowList t -> Type
+newtype BuildFormFor r tail = BuildFormFor { | r }
 
-class BuildForm (r :: # Type) (rl :: RowList) builder1 builder2 (hform :: # Type) | r rl builder1 -> builder2 hform where
+class BuildForm :: forall t. Row Type -> RowList t -> Type -> Type -> Row Type -> Constraint
+class BuildForm r rl builder1 builder2 hform | r rl builder1 -> builder2 hform where
   buildFormStep :: BuildFormFor r rl -> builder1 -> builder2
 
 instance buildFormNil :: BuildForm r RowList.Nil builder1 builder1 () where
@@ -372,7 +368,7 @@ instance buildFormCons ::
   , Row.Cons sym o () value'
   , Row.Lacks sym ()
   , Row.Cons sym (FormField m h2 ro i o) r' r
-  , Row.Cons sym (HProxy h2) hform' hform
+  , Row.Cons sym (Proxy h2) hform' hform
   ) =>
   BuildForm r
     (RowList.Cons sym (FormField m h2 ro i o) tail)


### PR DESCRIPTION
## What does this pull request do?

This PR updates the `hooks`-based version of the package to work with PureScript v0.14 and Halogen 6. So far I managed to get the basic examples to build but had to do some minor changes for `halogen-select` [here](<https://github.com/PureFunctor/purescript-halogen-select/commit/f1cfb78fd17c1f45fd7796ac1a2cec16c3637a2c>).

## Where should the reviewer start?

Quick synopsis for changes:
* Applied general updates for Halogen 6
* Unified proxy types to use just Proxy
* Removed use of HookEquals

## How should this be manually tested?

There shouldn't be any major changes in terms of behaviour.

## Other Notes:

External stuff:
- [x] `halogen-storybook` in package sets
- [ ] `halogen-select`