### PR TITLE
Add warning to mkSProxies

### DIFF
--- a/src/Formless/Transform/Row.purs
+++ b/src/Formless/Transform/Row.purs
@@ -9,6 +9,7 @@ import Formless.Internal.Transform (class Row1Cons, FromScratch, fromScratch)
 import Formless.Types.Form (InputField(..))
 import Prim.Row as Row
 import Prim.RowList as RL
+import Prim.TypeError (class Warn, Text)
 import Record.Builder as Builder
 import Type.Proxy (Proxy(..))
 
@@ -68,9 +69,13 @@ type SProxies form =
 
 -- | A helper function to produce a record of SProxies given a form spec, to save
 -- | you the boilerplate of writing them all out.
+-- |
+-- | WARNING: This can create significant code bloat, and it is not recommended
+-- | for production use.
 mkSProxies
   :: forall form xs inputs row
-   . RL.RowToList inputs xs
+   . Warn (Text "This function is not recommended for use in production settings due to large amounts of generated code.")
+  => RL.RowToList inputs xs
   => Newtype (form Record InputField) (Record inputs)
   => MakeSProxies xs row
   => Proxy form


### PR DESCRIPTION
## What does this pull request do?

Addresses #75 by adding a warning to the doc comment and a compiler warning to the `mkSProxies` function. Example output:

```
[5/5 UserDefinedWarning] example/real-world/OptionsForm.purs:119:1

  119  prx :: F.SProxies OptionsForm
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  
  A custom warning occurred while solving type class constraints:
  
    This function is not recommended for use in production settings due to large amounts of generated code.
  
  in value declaration prx
```
