### PR TITLE
Add submitPreventDefault to Formless when using forms

### DIFF
--- a/example/Main.purs
+++ b/example/Main.purs
@@ -8,6 +8,7 @@ import Effect (Effect)
 import Effect.Aff (Aff)
 import Example.Basic.Component as Basic
 import Example.Async.Component as Async
+import Example.Readme.Component as Readme
 import Example.Nested.Page as Nested
 import Example.ExternalComponents.Page as ExternalComponents
 import Example.App.Home as Home
@@ -25,6 +26,7 @@ stories = Object.fromFoldable
   , Tuple "async" $ proxy Async.component
   , Tuple "nested" $ proxy Nested.component
   , Tuple "real-world" $ proxy RealWorld.component
+  , Tuple "readme" $ proxy Readme.component
   ]
 
 main :: Effect Unit

--- a/example/readme/Component.purs
+++ b/example/readme/Component.purs
@@ -1,0 +1,121 @@
+-- | This example component shows how submitPreventDefault works in Halogen Formless
+module Example.Readme.Component (component) where
+
+import Prelude
+
+import Data.Either (Either(..))
+import Data.Int as Int
+import Data.Maybe (Maybe(..))
+import Data.Newtype (class Newtype, unwrap)
+import Effect.Aff.Class (class MonadAff)
+import Effect.Class.Console (logShow)
+import Example.App.UI.Element as UI
+import Example.App.Validation (class ToText)
+import Formless as F
+import Halogen as H
+import Halogen.HTML as HH
+import Halogen.HTML.Events as HE
+import Halogen.HTML.Properties as HP
+import Type.Proxy (Proxy(..))
+
+type Dog = { name :: String, age :: Age }
+
+newtype Age = Age Int
+
+derive instance newtypeAge :: Newtype Age _
+
+instance showAge :: Show Age where
+  show = show <<< unwrap
+
+data AgeError = TooLow | TooHigh | InvalidInt
+
+newtype DogForm (r :: Row Type -> Type) f = DogForm (r
+  --          error    input  output
+  ( name :: f Void     String String
+  , age  :: f AgeError String Age
+  ))
+
+derive instance newtypeDogForm :: Newtype (DogForm r f) _
+
+instance ToText AgeError where
+  toText = case _ of
+    InvalidInt -> "Age must be an integer"
+    TooLow -> "Age cannot be negative"
+    TooHigh -> "No dog has lived past 30 before"
+
+input :: forall m. Monad m => F.Input' DogForm m
+input =
+  { initialInputs: Nothing -- same as: Just (F.wrapInputFields { name: "", age: "" })
+  , validators: DogForm
+      { name: F.noValidation
+      , age: F.hoistFnE_ \str -> case Int.fromString str of
+          Nothing -> Left InvalidInt
+          Just n
+            | n < 0 -> Left TooLow
+            | n > 30 -> Left TooHigh
+            | otherwise -> Right (Age n)
+      }
+  }
+
+spec :: forall input m. Monad m => F.Spec' DogForm Dog input m
+spec = F.defaultSpec { render = render, handleEvent = F.raiseResult }
+  where
+  render st@{ form } =
+    UI.formContent_
+      [ HH.form
+        [ -- Using a form forces us to deal with an event. Using '\_ -> F.submit' here
+          -- would fire the event and cause the page to reload. Instead, we use
+          -- 'F.submitPreventDefault' to avoid firing the event unnecessarily
+          HE.onSubmit F.submitPreventDefault
+        ]
+        [ UI.input
+              { label: "Name"
+              , help: Right "Write your dog's name"
+              , placeholder: "Mila"
+              }
+              [ HP.value $ F.getInput _name st.form
+              , HE.onValueInput (F.setValidate _name)
+              ]
+        , UI.input
+              { label: "Age"
+              , help: UI.resultToHelp "Write your dog's age" $ F.getResult _age st.form
+              , placeholder: "3"
+              }
+              [ HP.value $ F.getInput _age form
+              , HE.onValueInput $ F.setValidate _age
+              ]
+        , UI.buttonPrimary
+            []
+            [ HH.text "Submit" ]
+        ]
+      ]
+    where
+    _name = Proxy :: Proxy "name"
+    _age = Proxy :: Proxy "age"
+
+data Action = HandleDogForm Dog
+
+component :: forall q i o m. MonadAff m => H.Component q i o m
+component = H.mkComponent
+  { initialState: const unit
+  , render: const render
+  , eval: H.mkEval $ H.defaultEval { handleAction = handleAction }
+  }
+  where
+  handleAction (HandleDogForm dog) = logShow (dog :: Dog)
+
+  render = 
+    UI.section_
+      [ UI.h1_ [ HH.text "Formless" ]
+      , UI.h2_ [ HH.text "A form using a default form element" ]
+      , UI.p_
+          """
+          In formless, if you use a default form you would notice a page refresh when submitting the form.
+          In the other examples, this is avoided by not using a form element. In this example, we use
+          a special function F.submitPreventDefault to avoid the page refresh.
+
+          You can download the examples and replace F.submitPreventDefault with
+          \_ -> F.submit to see the difference.
+          """
+      , HH.slot F._formless unit (F.component (const input) spec) unit HandleDogForm
+      ]

--- a/example/readme/Component.purs
+++ b/example/readme/Component.purs
@@ -107,15 +107,6 @@ component = H.mkComponent
   render = 
     UI.section_
       [ UI.h1_ [ HH.text "Formless" ]
-      , UI.h2_ [ HH.text "A form using a default form element" ]
-      , UI.p_
-          """
-          In formless, if you use a default form you would notice a page refresh when submitting the form.
-          In the other examples, this is avoided by not using a form element. In this example, we use
-          a special function F.submitPreventDefault to avoid the page refresh.
-
-          You can download the examples and replace F.submitPreventDefault with
-          \_ -> F.submit to see the difference.
-          """
+      , UI.h2_ [ HH.text "The form from the readme" ]
       , HH.slot F._formless unit (F.component (const input) spec) unit HandleDogForm
       ]

--- a/readme.md
+++ b/readme.md
@@ -91,7 +91,9 @@ spec :: forall input m. Monad m => F.Spec' DogForm Dog input m
 spec = F.defaultSpec { render = render, handleEvent = F.raiseResult }
   where
   render st@{ form } =
-    HH.form_
+    HH.form
+      [ HE.onSubmit F.submitPreventDefault
+      ]
       [ HH.input
           [ HP.value $ F.getInput _name form
           , HE.onValueInput $ F.set _name
@@ -105,8 +107,7 @@ spec = F.defaultSpec { render = render, handleEvent = F.raiseResult }
           Just InvalidInt -> "Age must be an integer"
           Just TooLow -> "Age cannot be negative"
           Just TooHigh -> "No dog has lived past 30 before"
-      , HH.button
-          [ HE.onClick \_ -> F.submit ]
+      , HH.button_
           [ HH.text "Submit" ]
       ]
     where

--- a/spago.dhall
+++ b/spago.dhall
@@ -24,6 +24,7 @@
   , "typelevel-prelude"
   , "unsafe-coerce"
   , "variant"
+  , "web-events"
   ]
 , packages = ./packages.dhall
 , sources = [ "src/**/*.purs" ]

--- a/src/Formless.purs
+++ b/src/Formless.purs
@@ -20,7 +20,7 @@ module Formless
   , module Formless.Validation
   ) where
 
-import Formless.Action (asyncModifyValidate, asyncSetValidate, injAction, loadForm, modify, modifyAll, modifyValidate, modifyValidateAll, reset, resetAll, set, setAll, setValidate, setValidateAll, submit, validate, validateAll)
+import Formless.Action (asyncModifyValidate, asyncSetValidate, injAction, loadForm, modify, modifyAll, modifyValidate, modifyValidateAll, reset, resetAll, set, setAll, setValidate, setValidateAll, submit, submitPreventDefault, validate, validateAll)
 import Formless.Class.Initial (class Initial, initial)
 import Formless.Component (component, defaultSpec, handleAction, handleQuery, raiseResult)
 import Formless.Data.FormFieldResult (FormFieldResult(..), _Error, _Success, fromEither, toMaybe)

--- a/src/Formless/Action.purs
+++ b/src/Formless/Action.purs
@@ -12,7 +12,6 @@ import Data.Symbol (class IsSymbol)
 import Data.Time.Duration (Milliseconds)
 import Data.Tuple (Tuple(..))
 import Data.Variant (Variant, inj)
-import Formless as F
 import Formless.Class.Initial (class Initial, initial)
 import Formless.Transform.Record (WrapField, wrapInputFields, wrapInputFunctions)
 import Formless.Types.Component (Action)

--- a/src/Formless/Action.purs
+++ b/src/Formless/Action.purs
@@ -265,8 +265,9 @@ resetAll :: forall v. Variant (resetAll :: Unit | v)
 resetAll =
   inj (Proxy :: _ "resetAll") unit
 
--- | Submit the form, which will trigger a `Submitted` result if the
--- | form validates successfully.
+-- | Submit the form, which will trigger a `Submitted` result if the form
+-- | validates successfully. If you want to capture the form submission event
+-- | and submit your form use `submitPreventDefault`.
 -- |
 -- | ```purescript
 -- | [ HE.onClick \_ -> Just F.submit ]

--- a/src/Formless/Action.purs
+++ b/src/Formless/Action.purs
@@ -275,12 +275,13 @@ submit :: forall v. Variant (submit :: Unit | v)
 submit =
   inj (Proxy :: _ "submit") unit
 
--- | Submit the form, which will trigger a `Submitted` result if the form
--- | validates successfully. Calls `preventDefault` (`Web.Event.Event`) on the
--- | event
+-- | Submit the form, calling `preventDefault` from `Web.Event.Event` on the 
+-- | submission event to prevent the browser from refreshing the page.
 -- |
 -- | ```purescript
--- | [ HE.onSubmit F.submitPreventDefault ]
+-- | HH.form
+-- |   [ HE.onSubmit F.submitPreventDefault ]
+-- |   [ ... ]
 -- | ```
 submitPreventDefault
   :: forall v

--- a/src/Formless/Action.purs
+++ b/src/Formless/Action.purs
@@ -12,6 +12,7 @@ import Data.Symbol (class IsSymbol)
 import Data.Time.Duration (Milliseconds)
 import Data.Tuple (Tuple(..))
 import Data.Variant (Variant, inj)
+import Formless as F
 import Formless.Class.Initial (class Initial, initial)
 import Formless.Transform.Record (WrapField, wrapInputFields, wrapInputFunctions)
 import Formless.Types.Component (Action)
@@ -19,6 +20,7 @@ import Formless.Types.Form (InputField, InputFunction, U(..))
 import Heterogeneous.Mapping as HM
 import Prim.Row as Row
 import Type.Proxy (Proxy(..))
+import Web.Event.Event as Event
 
 -- | Inject your own action into the Formless component so it can be used in HTML
 injAction :: forall form act. act -> Action form act
@@ -273,6 +275,19 @@ resetAll =
 submit :: forall v. Variant (submit :: Unit | v)
 submit =
   inj (Proxy :: _ "submit") unit
+
+-- | Submit the form, which will trigger a `Submitted` result if the form
+-- | validates successfully. Calls `preventDefault` (`Web.Event.Event`) on the
+-- | event
+-- |
+-- | ```purescript
+-- | [ HE.onSubmit F.submitPreventDefault ]
+-- | ```
+submitPreventDefault
+  :: forall v
+   . Event.Event
+  -> Variant (submitPreventDefault :: Event.Event | v)
+submitPreventDefault = inj (Proxy :: _ "submitPreventDefault")
 
 -- | Load a form from a set of existing inputs. Useful for when you need to mount
 -- | Formless, perform some other actions like request data from the server, and

--- a/src/Formless/Component.purs
+++ b/src/Formless/Component.purs
@@ -12,7 +12,6 @@ import Data.Tuple (Tuple(..))
 import Data.Variant (Variant, match, inj, expand)
 import Effect.Aff.Class (class MonadAff)
 import Effect.Ref as Ref
-import Formless.Action (submitPreventDefault)
 import Formless.Action as FA
 import Formless.Data.FormFieldResult (FormFieldResult(..))
 import Formless.Internal.Component as IC

--- a/src/Formless/Component.purs
+++ b/src/Formless/Component.purs
@@ -318,13 +318,13 @@ handleAction handleAction' handleEvent action = flip match action
       handleEvent $ Changed $ IC.getPublicState new
 
   , submit: \_ -> do
-     _ <- IC.preSubmit
-     _ <- handleAction handleAction' handleEvent FA.validateAll
-     IC.submit >>= traverse_ (Submitted >>> handleEvent)
+      _ <- IC.preSubmit
+      _ <- handleAction handleAction' handleEvent FA.validateAll
+      IC.submit >>= traverse_ (Submitted >>> handleEvent)
 
   , submitPreventDefault: \event -> do
-     H.liftEffect $ Event.preventDefault event
-     handleAction handleAction' handleEvent FA.submit
+      H.liftEffect $ Event.preventDefault event
+      handleAction handleAction' handleEvent FA.submit
 
   , loadForm: \formInputs -> do
       let setFields rec = rec { allTouched = false, initialInputs = formInputs }

--- a/src/Formless/Component.purs
+++ b/src/Formless/Component.purs
@@ -318,15 +318,13 @@ handleAction handleAction' handleEvent action = flip match action
       handleEvent $ Changed $ IC.getPublicState new
 
   , submit: \_ -> do
-      _ <- IC.preSubmit
-      _ <- handleAction handleAction' handleEvent FA.validateAll
-      IC.submit >>= traverse_ (Submitted >>> handleEvent)
+     _ <- IC.preSubmit
+     _ <- handleAction handleAction' handleEvent FA.validateAll
+     IC.submit >>= traverse_ (Submitted >>> handleEvent)
 
   , submitPreventDefault: \event -> do
-      H.liftEffect $ Event.preventDefault event
-      _ <- IC.preSubmit
-      _ <- handleAction handleAction' handleEvent FA.validateAll
-      IC.submit >>= traverse_ (Submitted >>> handleEvent)
+     H.liftEffect $ Event.preventDefault event
+     handleAction handleAction' handleEvent FA.submit
 
   , loadForm: \formInputs -> do
       let setFields rec = rec { allTouched = false, initialInputs = formInputs }

--- a/src/Formless/Types/Component.purs
+++ b/src/Formless/Types/Component.purs
@@ -18,6 +18,7 @@ import Halogen.Query.ChildQuery (ChildQueryBox)
 import Halogen.Query.HalogenM (ForkId)
 import Type.Proxy (Proxy(..))
 import Type.Row (type (+))
+import Web.Event.Event as Event
 
 -- | A type representing the various functions that can be provided to extend
 -- | the Formless component. Usually only the `render` function is required,
@@ -62,6 +63,7 @@ type PublicAction form =
   , validateAll :: Unit
   , resetAll :: Unit
   , submit :: Unit
+  , submitPreventDefault :: Event.Event
   , loadForm :: form Record InputField
   )
 


### PR DESCRIPTION
## What does this pull request do?

Closes #79. In the examples, this is handled by not using form but many people will reach for what they are familiar with. It is quite confusing when you run into this especially as a beginner to frontend development. Therefore we suggest the addition of `F.submitPreventDefault` and make the appropriate changes to the readme to avoid this confusion altogether. Additionally, we add the example code in the readme to the examples directory.

## Where should the reviewer start?

I added some comments on where to start your review :smile: 

## How should this be manually tested?

You can bundle the examples with `spago -x example/example.dhall bundle-app --to ./dist/app.js` to launch the "readme" example and see the behavior. You can also modify the `onSubmit \_ -> F.submit` to see that the page refreshes.

## Other Notes:

It might be useful to modify the existing examples to now use form elements and the `F.submitPreventDefault` function.