### PR TITLE
Pin variant to the latest stable version.

### DIFF
--- a/packages.dhall
+++ b/packages.dhall
@@ -3,7 +3,7 @@ let upstream =
       https://github.com/purescript/package-sets/releases/download/psc-0.14.5-20211116/packages.dhall sha256:7ba810597a275e43c83411d2ab0d4b3c54d0b551436f4b1632e9ff3eb62e327a
 
 in  upstream
-  with variant.version = "map-variant"
+  with variant.version = "4bafe7e809ff6d8f220861684b16cf5fe0e12750"
   with variant.repo = "https://github.com/MonoidMusician/purescript-variant"
 
   with convertable-options = {


### PR DESCRIPTION
Closes https://github.com/thomashoneyman/purescript-halogen-formless/issues/86